### PR TITLE
Add feature for email functionality

### DIFF
--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -156,9 +156,10 @@ class Republication_Tracker_Tool_Article_Settings {
 
 		}
 
-		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget, $post );
+		$hide_republication_widget_by_filter = false;
+		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post ); 
 
-		if( true == $hide_republication_widget ){
+		if( true == $hide_republication_widget_by_filter ){
 			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/INN/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
 		} else {
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -136,7 +136,7 @@ $email_article = sprintf(
 	rawurlencode( html_entity_decode( get_the_title(), ENT_QUOTES, get_option( 'blog_charset' ) ) ), // subject
 	rawurlencode( html_entity_decode( $article_info, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // start of post content with article info
 	rawurlencode( html_entity_decode( $content, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // post content
-	rawurlencode( html_entity_decode( $attribution_statement, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // post content
+	rawurlencode( html_entity_decode( $attribution_statement, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // republication attribution statement
 	rawurlencode( htmlspecialchars_decode( $pixel ) ), // tracking pixel
 );
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -91,7 +91,7 @@ $pixel = sprintf(
 	'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s" style="max-width:200px;">',
 	esc_attr( get_site_url( ) ),
 	esc_attr( $post->ID ),
-	esc_attr( $analytics_id )
+	esc_attr( $analytics_id ),
 );
 
 /**
@@ -109,6 +109,36 @@ $article_info = sprintf(
 );
 // strip empty tags after automatically applying p tags
 $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
+
+/**
+ * The shareable article title, content, etc. in emailable form
+ * 
+ * @var HTML $email_article The mailto: link to email the entire article content in the following order:
+ * 
+ * Subject:
+ * %2$s - "Republish this story:"
+ * %3$s - post permalink
+ * 
+ * Body:
+ * %5$s - $article_info The article title, byline, source site, and date
+ * %0D%0A - carriage return, line feed
+ * %6$s - $content The article content
+ * %0D%0A - carriage return, line feed
+ * %7$s - $attribution_statement The article source
+ * %0D%0A - carriage return, line feed
+ * %8$s - $pixel The link for the republication tracking pixel
+ */
+$email_article = sprintf(
+	'<a class="btn" href="mailto:?subject=%2$s%3$s&body=%5$s%0D%0A%6$s%0D%0A%7$s%0D%0A%8$s" target="_blank"><i class="icon-mail"></i> %1$s</a>',
+	esc_attr( __( 'Email Article', 'republication-tracker-tool' ) ), // button text
+	esc_attr( __( 'Republish this story: ', 'republication-tracker-tool' ) ), // start of email subject
+	rawurlencode( html_entity_decode( get_the_permalink() ) ), // url
+	rawurlencode( html_entity_decode( get_the_title(), ENT_QUOTES, get_option( 'blog_charset' ) ) ), // subject
+	rawurlencode( html_entity_decode( $article_info, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // start of post content with article info
+	rawurlencode( html_entity_decode( $content, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // post content
+	rawurlencode( html_entity_decode( $attribution_statement, ENT_QUOTES, get_option( 'blog_charset' ) ) ), // post content
+	rawurlencode( htmlspecialchars_decode( $pixel ) ), // tracking pixel
+);
 
 /**
  * The licensing statement from this plugin
@@ -153,6 +183,8 @@ echo '<div id="republication-tracker-tool-modal-content" style="display:none;">'
 		)
 	);
 	?>
-	<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+	<button class="btn" onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 	<?php
+	echo $email_article;
+
 echo '</div>'; // #republication-tracker-tool-modal-content


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Added a `Email Article` button in the republish modal, next to `Copy to Clipboard`, to allow users to email the article content and pixel in this format:
```
 * Subject:
 * %2$s - "Republish this story:"
 * %3$s - post permalink
 * 
 * Body:
 * %5$s - $article_info The article title, byline, source site, and date
 * %0D%0A - carriage return, line feed
 * %6$s - $content The article content
 * %0D%0A - carriage return, line feed
 * %7$s - $attribution_statement The article source
 * %0D%0A - carriage return, line feed
 * %8$s - $pixel The link for the republication tracking pixel
```
- Sets `$hide_republication_widget_by_filter = false;` as a default before applying the `hide_republication_widget` filter, because of #67 

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #68 (not sure why I named this branch 27-* 🤦‍♂), #67 

## Testing/Questions

Features that this PR affects:

- Shareable content modal + email functionality
- `Hide Republication Widget` metabox on post editor

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Does the escaping/formatting look ok for the email subject and body? It's mostly copied from how `largo_post_social_links` formats the email sharing link

Steps to test this PR:

**Email functionality:**
1. Go to a post with the widget
2. Open modal and click `Email Article`
3. Verify the formatting matches what's posted above
4. Verify the content looks sane and the pixel and whatnot are inserted as expected.

**Hide Republication Widget metabox:**
1. Open the post editor for a post
2. Check `Hide the Republication sharing widget on this post?` to be true
3. Save
4. On refresh, make sure you can uncheck the checkbox instead of seeing the `The Republication sharing widget on this post is programatically disabled through the hide_republication_widget filter.` warning.