### PR TITLE
Add filter republication_tracker_tool_byline on byline text

### DIFF
--- a/includes/compatibility-co-authors-plus.php
+++ b/includes/compatibility-co-authors-plus.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Compatibility functionality for Co-Authors Plus
+ *
+ * @link https://wpvip.com/plugins/co-authors-plus/
+ * @link https://github.com/Automattic/Co-Authors-Plus
+ */
+
+/**
+ * Filter the Republication Tracker Tool Byline
+ *
+ * The reason that we're implementing a separate filter here is because
+ * CAP's filter on the_author isn't triggering here.
+ *
+ * @link https://github.com/Automattic/Co-Authors-Plus/blob/3.4.3/php/class-coauthors-template-filters.php#L18-L20 the filter that does not trigger
+ *
+ * @param String $author_string The string returned by get_the_author
+ * @since Co-Authors Plus 3.4.3
+ * @uses coauthors https://github.com/Automattic/Co-Authors-Plus/blob/3.4.3/template-tags.php#L210-L227
+ * @return String the plain-text byline
+ */
+function republication_tracker_tool_byline_filter_cap( $author_string ) {
+	return coauthors( null, null, null, null, false );
+}
+
+if ( function_exists( 'coauthors' ) ) {
+	add_filter( 'republication_tracker_tool_byline', 'republication_tracker_tool_byline_filter_cap', 10, 1 );
+}

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -2,6 +2,8 @@
 /**
  * This file provides an AJAX response containing the body of a post as well as some sharing information.
  *
+ * This operates within The Loop. $post is set to a specific post.
+ *
  * Expected URLs is something like /wp-content/plugins/republication-tracker-tool/includes/shareable-content.php?post=22078&_=1512494948576 or something
  * We aren't passing a NONCE; this isn't a form.
  */
@@ -97,17 +99,29 @@ $pixel = sprintf(
 /**
  * The article title, byline, source site, and date
  *
+ * In version TKTK, this switched from get_the_author_meta
+ *
  * @var HTML $article_info The article title, etc.
  */
 $article_info = sprintf(
-	// translators: %1$s is the post title, %2$s is the byline, %3$s is the site name, %4$s is the date in the format F j, Y
+	// translators: %1$s is the post title, %2$s is the byline, %3$s is the site name, %4$s is the date in the format F j, Y.
 	__( '<h1>%1$s</h1><p class="byline">by %2$s, %3$s <br />%4$s</p>', 'republication-tracker-tool' ),
 	wp_kses_post( get_the_title( $post ) ),
-	wp_kses_post( get_the_author_meta( 'display_name', $post->post_author ) ),
+	/**
+	 * Allow filtering of the byline that is output in the share dialog and the copyable plaintext.
+	 *
+	 * This is to provide support for plugins that do not implement
+	 * a filter on 'the_author', or in cases where the 'the_author'
+	 * filter returns incomplete information.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/get_the_author/
+	 * @link https://github.com/INN/republication-tracker-tool/issues/46
+	 */
+	wp_kses_post( apply_filters( 'republication_tracker_tool_byline', get_the_author() ) ),
 	wp_kses_post( get_bloginfo( 'name' ) ),
 	wp_kses_post( date( 'F j, Y', strtotime( $post->post_date ) ) )
 );
-// strip empty tags after automatically applying p tags
+// strip empty tags after automatically applying p tags.
 $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ In this plugin, the tracking is achieved through an image element included insid
 
 == Changelog ==
 
+- Adds a new filter, `republication_tracker_tool_byline`, which allows developers to change the byline that is output in the modal and in the sharable text. Pull request TKTK for https://github.com/INN/republication-tracker-tool/issues/46, sponsored by [the Center for Public Integrity](https://publicintegrity.org/).
+- Adds compatibility for Automattic's [Co-Authors Plus](https://wpvip.com/plugins/co-authors-plus/) plugin. Pull request TKTK for https://github.com/INN/republication-tracker-tool/issues/46, sponsored by [the Center for Public Integrity](https://publicintegrity.org/).
+
 = 1.0.2 =
 
 - Sets a default width for the site icon that is displayed at the bottom of republished articles. Previously it did not have a width set which was causing some sites to experience larger than expected images at the end of their republished articles.

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -14,6 +14,7 @@
 require plugin_dir_path( __FILE__ ).'includes/class-settings.php';
 require plugin_dir_path( __FILE__ ).'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ).'includes/class-widget.php';
+require plugin_dir_path( __FILE__ ).'includes/compatibility-co-authors-plus.php';
 
 /**
 * Main initiation class.


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a new filter, `republication_tracker_tool_byline`, which allows developers to change the byline that is output in the modal and in the sharable text.
- To test that filter, adds compatibility for Automattic's [Co-Authors Plus](https://wpvip.com/plugins/co-authors-plus/) plugin.

![Screen Shot 2020-08-26 at 19 12 04](https://user-images.githubusercontent.com/1754187/91365843-1339f280-e7d0-11ea-9089-406285efd841.png)


## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #46 and to make https://github.com/PublicI/umbrella-public-integrity/pull/66 possible

## Testing/Questions

Features that this PR affects:

- The sharable content modal

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] Should the CAP functionality be tested?

Steps to test this PR:

1. Check out this branch on a site that does not have CAP installed. Make sure that this branch functions as intended without CAP installed.
2. Install, but do not activate CAP. Make sure that this branch functions as intended without CAP active.
3. Activate this plugin and assign multiple authors to an article. Verify that the authors appear in the sharable dialog and the copyable plaintext.
4. Deactivate CAP and verify that the RTT plugin continues to function after CAP is deactivated.

Before merging this PR:

- [ ] update `readme.txt` to replace `TKTK` with this PR number.
- [ ] improve documentation

## Additional information

INN Member/Labs Client requesting: The Center for Public Integrity

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] Contributor would like to be mentioned in the release notes as: The Center for Public Integrity
- [x] Contributor agrees to the license terms of this repository.
