### PR TITLE
Add AMP support

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -5,115 +5,122 @@
  */
 .side-widget.republication_tracker_tool,
 .widget.republication_tracker_tool {
-    text-align: center;
-    max-width: 300px;
-    margin: 0 auto;
+  text-align: center;
+  max-width: 300px;
+  margin: 0 auto;
 }
 
 .side-widget.republication_tracker_tool p,
 .widget.republication_tracker_tool p {
-    margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 
 .side-widget.republication_tracker_tool a.license,
 .widget.republication_tracker_tool a.license {
-    border-top: 3px double #ddd;
-    border-bottom: 3px double #ddd;
-    padding: 1em 0;
-    min-width: 100%;
-    display: block;
+  border-top: 3px double #ddd;
+  border-bottom: 3px double #ddd;
+  padding: 1em 0;
+  min-width: 100%;
+  display: block;
 }
 
-.side-widget.republication_tracker_tool button.republication-tracker-tool-button,
+.side-widget.republication_tracker_tool
+  button.republication-tracker-tool-button,
 .widget.republication_tracker_tool button.republication-tracker-tool-button {
-    width:100%;
-    background-color: #5499db;
-    border: 1px solid #2863a7;
-    color: #fff;
-    padding: 1em;
-    font-size: 1.25em;
-    margin: 0 0 1em 0;
-    display: block;
-    border-radius: .25em;
-    font-weight: bold;
-    text-shadow: 1px 1px 1px #2863a7;
+  width: 100%;
+  background-color: #5499db;
+  border: 1px solid #2863a7;
+  color: #fff;
+  padding: 1em;
+  font-size: 1.25em;
+  margin: 0 0 1em 0;
+  display: block;
+  border-radius: 0.25em;
+  font-weight: bold;
+  text-shadow: 1px 1px 1px #2863a7;
 }
 
-.side-widget.republication_tracker_tool button.republication-tracker-tool-button:hover,
-.widget.republication_tracker_tool button.republication-tracker-tool-button:hover {
-    background-color: #2863a7;
-    text-decoration: none;
-    cursor: pointer;
+.side-widget.republication_tracker_tool
+  button.republication-tracker-tool-button:hover,
+.widget.republication_tracker_tool
+  button.republication-tracker-tool-button:hover {
+  background-color: #2863a7;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 #republication-tracker-tool-modal {
-    position: fixed;
-    z-index: 999999999;
-    top: 0;
-    left: 0;
-    width:100%;
-    height:100%;
-    background-color:rgba(0,0,0,.75);
+  position: fixed;
+  z-index: 999999999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.75);
 }
 
 #republication-tracker-tool-modal-content {
-    position: absolute;
-    width: 90%;
-    max-width: 800px;
-    max-height: 90%;
-    overflow: auto;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: #fff;
-    padding: 2em;
-    text-align: left;
-    width:
+  position: absolute;
+  width: 90%;
+  max-width: 800px;
+  max-height: 90%;
+  overflow: auto;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #fff;
+  padding: 2em;
+  text-align: left;
+  width: ;
 }
 
 #republication-tracker-tool-modal-content textarea {
-    box-sizing: border-box;
-    width: 100%;
-    margin:.5em 0 2em 0;
-    cursor: auto;
-    background-color: inherit;
-    border-color: inherit;
+  box-sizing: border-box;
+  width: 100%;
+  margin: 0.5em 0 2em 0;
+  cursor: auto;
+  background-color: inherit;
+  border-color: inherit;
 }
 
 #republication-tracker-tool-modal-content h2,
 #republication-tracker-tool-modal-content .cc-license,
 #republication-tracker-tool-modal-content .cc-policy {
-    border-bottom: 1px solid #ccc;
-    padding-bottom: 1em;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 1em;
 }
 
 #republication-tracker-tool-modal-content .cc-license,
 #republication-tracker-tool-modal-content .cc-policy {
-    margin-bottom: 2em;
+  margin-bottom: 2em;
 }
 
 #republication-tracker-tool-modal-content .cc-license img {
-    margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 
 #republication-tracker-tool-modal-content .article-info h1 {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .republication-tracker-tool-close {
-    position: absolute;
-    top: 0;
-    right: .5em;
-    font-family: sans-serif;
-    text-transform: lowercase;
-    font-size: 2em;
+  position: absolute;
+  top: 0;
+  right: 0.5em;
+  font-family: sans-serif;
+  text-transform: lowercase;
+  font-size: 2em;
 }
 
 .republication-tracker-tool-close:hover {
-    cursor:pointer;
-    opacity:.8;
+  cursor: pointer;
+  opacity: 0.8;
 }
 
 .modal-open-disallow-scrolling {
-    overflow: hidden;
+  overflow: hidden;
+}
+
+.republication_tracker_tool .license img {
+  width: 88px;
 }

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -20,7 +20,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 	 */
 	public function __construct() {
 		$widget_ops = array(
-			'classname' => 'republication_tracker_tool',
+			'classname'   => 'republication_tracker_tool',
 			'description' => esc_html__( 'Republication Tracker Tool', 'republication-tracker-tool' ),
 		);
 		parent::__construct( 'republication_tracker_tool', 'Republication Tracker Tool', $widget_ops );
@@ -46,16 +46,15 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		// if `republication-tracker-tool-hide-widget` meta is set to true, don't show the shareable content widget
 		// OR if the `hide_republication_widget` filter is set to true, don't show the shareable content widget
-		if( true == $hide_republication_widget_on_post ) {
-				
+		if ( true == $hide_republication_widget_on_post ) {
 			return;
-			
 		}
-		
-		// define our path to grab file content from
-		$republication_plugin_path = plugin_dir_path( __FILE__ );
 
-		wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), Republication_Tracker_Tool::VERSION, false );
+		$is_amp = self::is_amp();
+
+		if ( ! $is_amp ) {
+			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), Republication_Tracker_Tool::VERSION, false );
+		}
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), Republication_Tracker_Tool::VERSION );
 
 		echo wp_kses_post( $args['before_widget'] );
@@ -66,13 +65,13 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		echo '<div class="license">';
 			echo sprintf(
-				'<p><button name="%1$s" id="cc-btn" class="republication-tracker-tool-button">%1$s</button></p>',
+				'<p><button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal"' : '' ) . ' name="%1$s" id="cc-btn" class="republication-tracker-tool-button">%1$s</button></p>',
 				esc_html__( 'Republish This Story', 'republication-tracker-tool' )
 			);
 			echo sprintf(
 				'<p><a class="license" rel="license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
 				esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
-				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ).'assets/img/creative-commons-sharing.png'
+				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/creative-commons-sharing.png'
 			);
 		echo '</div>';
 
@@ -84,18 +83,27 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		echo wp_kses_post( $args['after_widget'] );
 
 		// if has_instance is false, we can continue with displaying the modal
-		if( isset( $this->has_instance ) && false === $this->has_instance ){
+		if ( isset( $this->has_instance ) && false === $this->has_instance ) {
 
 			// update has_instance so the next time the widget is created on the same page, it does not create a second modal
 			$this->has_instance = true;
 
-			printf(
-				'<div id="republication-tracker-tool-modal" style="display:none;" data-postid="%1$s" data-pluginsdir="%2$s">%3$s</div>',
-				esc_attr( $post->ID ),
-				esc_attr( plugins_url() ),
-				esc_html( include_once( $republication_plugin_path . 'shareable-content.php' ) )
-			);
+			// define our path to grab file content from
+			$modal_content_path = plugin_dir_path( __FILE__ ) . 'shareable-content.php';
 
+			if ( $is_amp ) {
+				?>
+					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay">
+						<?php echo esc_html( include_once $modal_content_path ); ?>
+					</amp-lightbox>
+				<?php
+			} else {
+				?>
+					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>">
+						<?php echo esc_html( include_once $modal_content_path ); ?>
+					</div>
+				<?php
+			}
 		}
 	}
 
@@ -107,7 +115,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 	public function form( $instance ) {
 		echo sprintf( '<p><em>%s</em></p>', esc_html__( 'This widget will only display on single articles.', 'republication-tracker-tool' ) );
 		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
-		$text = ! empty( $instance['text'] ) ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under a Creative Commons license.', 'text_domain' );
+		$text  = ! empty( $instance['text'] ) ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under a Creative Commons license.', 'text_domain' );
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr_e( 'Title:', 'text_domain' ); ?></label>
@@ -131,8 +139,12 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		$instance = array();
 
 		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? wp_strip_all_tags( $new_instance['title'] ) : '';
-		$instance['text'] = ( ! empty( $new_instance['text'] ) ) ? $new_instance['text'] : '';
+		$instance['text']  = ( ! empty( $new_instance['text'] ) ) ? $new_instance['text'] : '';
 
 		return $instance;
+	}
+
+	public static function is_amp() {
+		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 	}
 }

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -57,8 +57,6 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), Republication_Tracker_Tool::VERSION, false );
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), Republication_Tracker_Tool::VERSION );
-		add_action( 'wp_ajax_my_action', 'my_action' );
-		add_action( 'wp_ajax_nopriv_my_action', 'my_action' );
 
 		echo wp_kses_post( $args['before_widget'] );
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -147,7 +147,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			'<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">%1$s %2$s %3$s</textarea>',
 			esc_html( $article_info ),
 			$content . "\n\n",
-			wpautop( $attribution_statement . $pixel )
+			wpautop( $attribution_statement . htmlentities( $pixel ) )
 		)
 	);
 	if ( ! $is_amp ) {

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -31,7 +31,7 @@ unset( $allowed_tags_excerpt['form'] );
 
 /**
  * Allow sites to configure which tags are allowed to be output in the republication content
- * 
+ *
  * Default value is the standard global $allowedposttags, except form elements.
  *
  * @link https://github.com/INN/republication-tracker-tool/issues/49
@@ -65,8 +65,6 @@ $content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
 // grab our analytics id to pass as GA param
 $analytics_id = get_option( 'republication_tracker_tool_analytics_id' );
 
-
-
 /**
  * The article source
  *
@@ -89,7 +87,7 @@ $attribution_statement = sprintf(
 $pixel = sprintf(
 	// %1$s is the javascript source, %2$s is the post ID, %3$s is the plugins URL
 	'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s" style="max-width:200px;">',
-	esc_attr( get_site_url( ) ),
+	esc_attr( get_site_url() ),
 	esc_attr( $post->ID ),
 	esc_attr( $analytics_id )
 );
@@ -117,15 +115,15 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 
-echo '<div id="republication-tracker-tool-modal-content" style="display:none;">';
-	echo '<div class="republication-tracker-tool-close">X</div>';
+echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
+	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">X</div>';
 	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
 			echo sprintf( '<a rel="license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a>', esc_html__( 'Creative Commons License' ) );
-			echo wp_kses_post( 
+			echo wp_kses_post(
 				wpautop(
 					sprintf(
 						// translators: %1$s is the URL to the particular Creative Commons license.
@@ -144,15 +142,18 @@ echo '<div id="republication-tracker-tool-modal-content" style="display:none;">'
 	echo '</div>'; // .article-info
 
 	// the text area that is copyable
-	echo wp_kses_post( 
+	echo wp_kses_post(
 		sprintf(
 			'<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">%1$s %2$s %3$s</textarea>',
 			esc_html( $article_info ),
-			$content . "\n\n" ,
+			$content . "\n\n",
 			wpautop( $attribution_statement . $pixel )
 		)
 	);
-	?>
-	<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
-	<?php
+	if ( ! $is_amp ) {
+		?>
+			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+		<?php
+	}
+
 echo '</div>'; // #republication-tracker-tool-modal-content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,401 @@
+{
+  "name": "republication-tracker-tool",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
+      },
+      "dependencies": {
+        "underscore.string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+          "dev": true
+        }
+      }
+    },
+    "async": {
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
+    },
+    "coffee-script": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+      "dev": true
+    },
+    "colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+      "dev": true
+    },
+    "dateformat": {
+      "version": "1.0.2-1.2.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "dev": true
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "findup-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+      "dev": true,
+      "requires": {
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
+    "getobject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+      "dev": true
+    },
+    "gettext-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.1.2.tgz",
+      "integrity": "sha1-zw8MnJCJrtsO5RSZKRg+ncQ1hKc=",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11"
+      }
+    },
+    "glob": {
+      "version": "3.1.21",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+          "dev": true
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+      "dev": true
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
+    "grunt-legacy-log": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-log-utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+      "dev": true,
+      "requires": {
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-legacy-util": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+      "dev": true,
+      "requires": {
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
+      }
+    },
+    "grunt-wp-i18n": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/grunt-wp-i18n/-/grunt-wp-i18n-0.5.4.tgz",
+      "integrity": "sha1-hynlrU9LIxJpch8xcWVNLGKVVJI=",
+      "dev": true,
+      "requires": {
+        "async": "~0.9.0",
+        "gettext-parser": "~1.1.0",
+        "grunt": "~0.4.5",
+        "underscore": "~1.8.2",
+        "underscore.string": "~3.0.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+          "integrity": "sha1-Rhe4waJQz25QZPu7Nj0PqWzxRVI=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-wp-readme-to-markdown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-wp-readme-to-markdown/-/grunt-wp-readme-to-markdown-1.0.0.tgz",
+      "integrity": "sha1-dJ/9gDtYTVC9ZOc6ehqRhz6djPs=",
+      "dev": true
+    },
+    "hooker": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "dev": true,
+      "requires": {
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
+      }
+    },
+    "lodash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "rimraf": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "republication-tracker-tool",
   "version": "0.1.0",


### PR DESCRIPTION
Adds support for AMP pages. 
Closes #57 

## How to test

1. Add the republication tracker widget as described [in the docs](https://github.com/Automattic/republication-tracker-tool/tree/master/docs)
2. Visit a post in non-AMP mode - observe everything working as before 
3. Visit a post in AMP mode - ~observe the in the widget area is the same, but after clicking the button which opens the modal, a new browser tab opens with the modal content~ observe that the modal is also shown after clicking the button, as on the non-AMP version
4. Observe that the AMP version does not sport a "Copy to clipboard" button and instead links to the original article
