### PR TITLE
Add tracking pixel if attribution statement is not displayed

### DIFF
--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -62,7 +62,7 @@ $content = str_replace( '<p></p>', '', wpautop( $content ) );
 // Force the content to be UTF-8 escaped HTML.
 $content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
 
-$attribution_statement = Republication_Tracker_Tool::create_attribution_markup( $post );
+$content_footer = Republication_Tracker_Tool::create_content_footer( $post );
 
 /**
  * The article title, byline, source site, and date
@@ -119,7 +119,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 					'<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">%1$s %2$s %3$s</textarea>',
 					esc_html( $article_info ),
 					$content . "\n\n",
-					$attribution_statement
+					$content_footer
 				)
 			);
 			if ( ! $is_amp ) {

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -217,7 +217,9 @@ final class Republication_Tracker_Tool {
 	 *
 	 * @param $post The shared post.
 	 */
-	public static function create_attribution_markup( $post = null ) {
+	public static function create_content_footer( $post = null ) {
+		$pixel = self::create_tracking_pixel_markup( $post->ID );
+
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 		if ( 'on' === $display_attribution && null !== $post ) {
 			$site_icon_markup = '';
@@ -229,8 +231,6 @@ final class Republication_Tracker_Tool {
 				);
 			}
 
-			$pixel = self::create_tracking_pixel_markup( $post->ID );
-
 			return wpautop(
 				sprintf(
 				// translators: %1$s is a URL, %2$s is the site home URL, and %3$s is the site title.
@@ -241,7 +241,7 @@ final class Republication_Tracker_Tool {
 				) . htmlentities( $site_icon_markup ) . htmlentities( $pixel )
 			);
 		}
-		return '';
+		return htmlentities( $pixel );
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug.

### How to test the changes in this Pull Request:

1. On `master`, disable "Display attribution" in RTT settings (in Settings->Reading)
2. Observe that the tracking pixel is missing in the copyable content
3. Switch to this branch, observe the pixel is in copyable content regardless of the "Display attribution" setting
