### PR TITLE
Fix: rel attribute on links

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -69,7 +69,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 				esc_html__( 'Republish This Story', 'republication-tracker-tool' )
 			);
 			echo sprintf(
-				'<p><a class="license" rel="noreferrer" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
+				'<p><a class="license" rel="noreferrer license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
 				esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
 				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/creative-commons-sharing.png'
 			);

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -69,7 +69,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 				esc_html__( 'Republish This Story', 'republication-tracker-tool' )
 			);
 			echo sprintf(
-				'<p><a class="license" rel="license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
+				'<p><a class="license" rel="noreferrer" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
 				esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
 				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/creative-commons-sharing.png'
 			);

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -94,12 +94,12 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
-			echo sprintf( '<a rel="license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a>', esc_html__( 'Creative Commons License' ) );
+			echo sprintf( '<a rel="noreferrer" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a>', esc_html__( 'Creative Commons License' ) );
 			echo wp_kses_post(
 				wpautop(
 					sprintf(
 						// translators: %1$s is the URL to the particular Creative Commons license.
-						__( 'This work is licensed under a <a rel="license" target="_blank" href="%1$s">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.' ),
+						__( 'This work is licensed under a <a rel="noreferrer" target="_blank" href="%1$s">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.' ),
 						'http://creativecommons.org/licenses/by-nd/4.0/'
 					)
 				)

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -94,12 +94,12 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
-			echo sprintf( '<a rel="noreferrer" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a>', esc_html__( 'Creative Commons License' ) );
+			echo sprintf( '<a rel="noreferrer license" target="_blank" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="%s" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a>', esc_html__( 'Creative Commons License' ) );
 			echo wp_kses_post(
 				wpautop(
 					sprintf(
 						// translators: %1$s is the URL to the particular Creative Commons license.
-						__( 'This work is licensed under a <a rel="noreferrer" target="_blank" href="%1$s">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.' ),
+						__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.' ),
 						'http://creativecommons.org/licenses/by-nd/4.0/'
 					)
 				)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Links to external sites should have this attribute. More on that here: https://web.dev/external-anchors-use-rel-noopener

### How to test the changes in this Pull Request:

1. On `master`, run Lighthouse (in Chrome devtools) "Best Practices" audit
2. Observe issue about unsafe links reported
3. Switch to this branch, rerun the audit, observe no issue (at least not originating from this plugin's code)
