### PR TITLE
fix: prevent GA pings from WP Admin

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -61,6 +61,11 @@ if ( isset( $_GET['post'] ) ) {
 
 	}
 
+	// If the request is coming from WP Admin, bail out (when the copied content is inserted into the WP editor, the pixel will be pinged).
+	if ( false !== stripos( $url, '/wp-admin/' ) ) {
+		return;
+	}
+
 	$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );
 	if ( $value ) {
 		if ( isset( $value[ $url ] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As it says on the tin.

### How to test the changes in this Pull Request:

1. On `master`,
2. Place the RTT widget in the sidebar, and use it to copy content of a post
3. To verify that a ping is sent to GA, log something [around here](https://github.com/Automattic/republication-tracker-tool/blob/8f991db9f567a4f49bd4fe5c50d40b6d5583d739/includes/pixel.php#L108)
4. Insert the copied content into the post editor, while in code editor mode
5. Observe that a ping is sent to GA, because the editor contains the tracking pixel
6. Switch to this branch. observe the ping is not sent
7. Publish the republished post, visit it - observe the ping is sent to GA as expected
