### PR TITLE
fix: exit if pinging from wp-admin

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -63,7 +63,7 @@ if ( isset( $_GET['post'] ) ) {
 
 	// If the request is coming from WP Admin, bail out (when the copied content is inserted into the WP editor, the pixel will be pinged).
 	if ( false !== stripos( $url, '/wp-admin/' ) ) {
-		return;
+		exit;
 	}
 
 	$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small thing. Technically, `exit` should be performed instead of `return` to finish the ping request . 

### How to test the changes in this Pull Request:

Same as in #119 