### PR TITLE
Add screen reader accessible label to the modal close button

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -124,3 +124,16 @@
 .republication_tracker_tool .license img {
   width: 88px;
 }
+
+.screen-reader-text {
+  border: 0;
+  clip: rect( 1px, 1px, 1px, 1px );
+  clip-path: inset( 50% );
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -88,7 +88,8 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
-	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">X</div>';
+	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
+	echo '<span role="presentation">X</span> <span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span></div>';
 	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -89,7 +89,7 @@ $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_polic
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
-	echo '<span role="presentation">X</span> <span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span></div>';
+	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></div>';
 	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons


### PR DESCRIPTION
This PR adds the a label to the modal dialog close button that can be read by screen readers, but is not actually visible.

It also adds the `aria-hidden="true"` to the `X` that's used as the visible close button label, so screen readers will ignore it. 

Closes #134

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Open the dialog on a test site; confirm that the button displays an X, and no visible label. 

![image](https://user-images.githubusercontent.com/177561/165379933-6b90f517-b095-4c27-b053-86eebf749299.png)

3. Confirm that the screen reader label is available in the source:

![image](https://user-images.githubusercontent.com/177561/165380232-caea8c4d-8e20-4230-b297-34dd91cafa1b.png)

4. Bonus test: use a screen reader (like Mac's VoiceOver Utility, under System Preferences > Accessibility > VoiceOver), to navigate the page and confirm that it reads the 'Close window' text: 

![Screen Shot 2022-04-26 at 12 47 39 PM](https://user-images.githubusercontent.com/177561/165380395-4596f54e-3d7c-45fa-8fd2-34907309d89d.png)

