### PR TITLE
Add `role` and `aria-modal` attributes to popup

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -93,13 +93,13 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 			if ( $is_amp ) {
 				?>
-					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay">
+					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay" role="dialog" aria-modal="true">
 						<?php echo esc_html( include_once $modal_content_path ); ?>
 					</amp-lightbox>
 				<?php
 			} else {
 				?>
-					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>">
+					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>" role="dialog" aria-modal="true">
 						<?php echo esc_html( include_once $modal_content_path ); ?>
 					</div>
 				<?php

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -87,7 +87,7 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 
-echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
+echo '<div id="republication-tracker-tool-modal-content" role="dialog" aria-modal="true"' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">X</div>';
 	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -87,7 +87,7 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 
-echo '<div id="republication-tracker-tool-modal-content" role="dialog" aria-modal="true"' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
+echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">X</div>';
 	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the HTML attributes `role="dialog"` and `aria-modal="true"` to the modal dialog opened by the plugin, to improve accessibility. This change was based on some feedback in a publisher's third-part accessibility report.

Closes #135

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Click the Republish this Story button on your test site.
3. Inspect the HTML; confirm that the `role="dialog"` and `aria-modal="true"` and present in the markup on the dialog box container:

![image](https://user-images.githubusercontent.com/177561/165382518-79599d7b-14c7-4978-b42b-fade20a44e74.png)

![image](https://user-images.githubusercontent.com/177561/165382648-90cb200e-7209-4b11-90e7-506ab4b5b806.png)
