### PR TITLE
fix: increase button background contrast

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -28,8 +28,8 @@
   button.republication-tracker-tool-button,
 .widget.republication_tracker_tool button.republication-tracker-tool-button {
   width: 100%;
-  background-color: #5499db;
-  border: 1px solid #2863a7;
+  background: #2a7ac2;
+  border: 1px solid #255b98;
   color: #fff;
   padding: 1em;
   font-size: 1.25em;
@@ -37,7 +37,7 @@
   display: block;
   border-radius: 0.25em;
   font-weight: bold;
-  text-shadow: 1px 1px 1px #2863a7;
+  text-shadow: 1px 1px 1px #255b98;
 }
 
 .side-widget.republication_tracker_tool


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR increases the contrast of the Republication button by switching it to a darker blue -- this improves accessibility by meeting WCAG 2.0 level AAA contrast ratio of 4.5:1 for larger text.

I tried to go with a colour that wouldn't read as extremely different from the current blue, and tweaked the border and text shadow colours to match. That being said, this issue originally came from a third-party accessibility review one of our publishers got, and is also fixed on their site using Custom CSS. So if this seems like too much of a change a this point, it would also work to close this issue as a `wontfix` and address this on a per-site basis if it comes up again in the future. 

Closes #133

### How to test the changes in this Pull Request:

1. Start with a site running the Republication Tracker plugin; view the button on the front end: 

![image](https://user-images.githubusercontent.com/177561/165392288-a4847256-8717-49f0-8cbd-3be27d6c6653.png)

2. Apply the PR and refresh the page (you may need to do a hard refresh).
3. Review the appearance of the button; you can [double-check if the contrast is sufficient (we want to pass WCAG AAA for Large text, or meet a contrast ratio of 4.5:1)](https://webaim.org/resources/contrastchecker/), and I would love some feedback as to whether this seems like too much of a change: 

![image](https://user-images.githubusercontent.com/177561/165392238-fd4cd038-077b-417e-89b1-13ed1799a45f.png)


