### PR TITLE
Consistent visibility of "Hide Republish Button" checkbox

### DIFF
--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -156,9 +156,10 @@ class Republication_Tracker_Tool_Article_Settings {
 
 		}
 
-		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget, $post );
+		$hide_republication_widget_by_filter = false;
+		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post ); 
 
-		if ( true == $hide_republication_widget ) {
+		if( true == $hide_republication_widget_by_filter ){
 			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
 		} else {
 


### PR DESCRIPTION
Updates code that determines whether Republication Tracker Tool's checkbox is shown in the post editor.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The checkbox is currently visible only on alternating views of the post editor, with its settings getting lost in between. Closes #67 & #170.

### How to test the changes in this Pull Request:

1. Create a post and check the "Hide the Republication sharing widget on this post?" box in the post settings.
2. Publish the post.
3. View the post on the frontend. Observe that the republication widget is not present.
4. Click "Edit Post".
5. Observe that the checkbox has been replaced with the notice "The Republication sharing widget on this post is programatically disabled through the hide_republication_widget filter. Read more about this filter." (This is a known issue: https://github.com/Automattic/republication-tracker-tool/issues/67)
6. Click "Update".
7. View the post on the frontend. Observe that the republication widget is now present.
8. Switch to this branch. The checkbox is now always visible, and the setting is preserved between edits.