### PR TITLE
fix: restore visibility of "shares" table in metabox

### DIFF
--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -113,7 +113,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		}
 		echo wp_kses_post( wpautop( 'Total number of views: ' . $total_count ) );
 		if ( is_array( $shares ) && ! empty( $shares ) ) {
-			echo '<table class="wp-list-table widefat fixed striped posts">';
+			echo '<table class="wp-list-table widefat striped posts">';
 				echo '<thead>';
 					echo sprintf( '<th scope="col" id="url" class="manage-column column-primary"><span>%s</span><span class="sorting-indicator"></span></th>', esc_html__( 'Republished URL', 'republication-tracker-tool' ) );
 					echo sprintf( '<th scope="col" id="views" class="manage-column ">%s</th>', esc_html__( 'Views', 'republication-tracker-tool' ) );
@@ -157,9 +157,9 @@ class Republication_Tracker_Tool_Article_Settings {
 		}
 
 		$hide_republication_widget_by_filter = false;
-		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post ); 
+		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post );
 
-		if( true == $hide_republication_widget_by_filter ){
+		if ( true == $hide_republication_widget_by_filter ) {
 			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
 		} else {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Restores visibility of the "shares" table of details in the edit post metabox. The `fixed` classname causes it to be hidden from view, possibly from a recent WP admin style change.

Closes `1204323000227080/1204364074266311`.

### How to test the changes in this Pull Request:

1. On `master` or `release`, share an article to another site via the Republication Tracker Tool widget. 
2. Edit the post on the original site and observe that the metabox shows total shares, but not the table of detailed share info:

<img width="231" alt="Screen Shot 2023-05-01 at 11 20 23 AM" src="https://user-images.githubusercontent.com/2230142/235495880-bf34563d-d5e1-47fe-b54f-9021de0acd47.png">

3. Check out this branch, refresh the editor, and confirm that the table is back:

<img width="772" alt="Screen Shot 2023-05-01 at 11 21 29 AM" src="https://user-images.githubusercontent.com/2230142/235496324-83b3b027-febe-4c6e-b554-9c426aa5ae48.png">
