### PR TITLE
feat: add support to tracking pixel for GA4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Republication Tracker Tool #
-**Contributors:** innlabs
-**Donate link:** https://inn.org/donate
+**Contributors:** innlabs, Automattic
 **Tags:** publishers, news
 **Requires at least:** 4.4
 **Requires PHP:** 5.3
@@ -13,12 +12,13 @@ Adds a widget to allow readers to easily acquire Creative-Commons-licensed HTML 
 
 ## Description ##
 
-A plugin that allows users to add a widget to allow readers to easily acquire Creative-Commons-licensed HTML of articles to facilitate embedding posts on external sites. Includes a tracking mechanism similar to ProPublica's PixelPing. Built and maintained by [INN Labs](https://labs.inn.org/).
+A plugin that allows users to add a widget to allow readers to easily acquire Creative-Commons-licensed HTML of articles to facilitate embedding posts on external sites. Includes a tracking mechanism similar to ProPublica's PixelPing. Built by [INN Labs](https://labs.inn.org/), now maintained by [Newspack](https://newspack.com/) and [Automattic](https://automattic.com/).
 
 ## Installation ##
 
-1. Activate the plugin through the 'Plugins' menu in WordPress
-1. Add the widget to your per-post sidebars. It doesn't work outside of single post pages.
+1. Activate the plugin through the 'Plugins' menu in WordPress.
+2. Configure plugin settings in the 'Settings' > 'Reading' menu.
+3. Add the widget to your per-post sidebars. It doesn't work outside of single post pages.
 
 ## Frequently Asked Questions ##
 
@@ -26,4 +26,4 @@ A plugin that allows users to add a widget to allow readers to easily acquire Cr
 
 The tracking mechanism is similiar to ProPublica's [PixelPing](https://www.propublica.org/pixelping) tracking technology.
 
-In this plugin, the tracking is achieved through an image element included inside of the republishable content that collects data from the republishing site and sends that data to Google Analytics.
+In this plugin, the tracking is achieved through an image element included inside of the republishable content that collects data from the republishing site and sends that data to Google Analytics. Shared content views are tracked as pageview events in Google Analytics, with the shared URL listed as referrer. Supports both Universal Analytics and Google Analytics 4 protocols.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Republication Tracker Tool #
-**Contributors:** innlabs  
-**Donate link:** https://inn.org/donate  
-**Tags:** publishers, news  
-**Requires at least:** 4.4  
-**Requires PHP:** 5.3  
-**Tested up to:** 5.2.2  
-**Stable tag:** 1.0.2  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Contributors:** innlabs
+**Donate link:** https://inn.org/donate
+**Tags:** publishers, news
+**Requires at least:** 4.4
+**Requires PHP:** 5.3
+**Tested up to:** 6.2
+**Stable tag:** 1.0.2
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Adds a widget to allow readers to easily acquire Creative-Commons-licensed HTML of articles to facilitate embedding posts on external sites. Includes a tracking mechanism similar to ProPublica's PixelPing.
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -53,8 +53,18 @@ class Republication_Tracker_Tool_Settings {
 			],
 			[
 				'key'      => 'republication_tracker_tool_analytics_id',
-				'label'    => esc_html__( 'Google Analytics ID', 'republication-tracker-tool' ),
+				'label'    => esc_html__( 'Google Analytics UA ID', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_analytics_id_callback' ),
+			],
+			[
+				'key'      => 'republication_tracker_tool_analytics_ga4_id',
+				'label'    => esc_html__( 'Google Analytics 4 ID', 'republication-tracker-tool' ),
+				'callback' => array( $this, 'republication_tracker_tool_analytics_ga4_id_callback' ),
+			],
+			[
+				'key'      => 'republication_tracker_tool_analytics_ga4_secret',
+				'label'    => esc_html__( 'Google Analytics 4 API Secret', 'republication-tracker-tool' ),
+				'callback' => array( $this, 'republication_tracker_tool_analytics_ga4_secret_callback' ),
 			],
 			[
 				'key'      => 'republication_tracker_tool_display_attribution',
@@ -115,15 +125,36 @@ class Republication_Tracker_Tool_Settings {
 				'teeny'         => true,
 			)
 		);
-		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy hat uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/master/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.' ) );
+		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy hat uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/master/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.', 'republication-tracker-tool' ) ) );
 	}
 
 	public function republication_tracker_tool_analytics_id_callback() {
 		$content = get_option( 'republication_tracker_tool_analytics_id' );
 		echo sprintf(
-			'<input type="text" name="%1$s" value="%2$s">',
+			'<input type="text" name="%1$s" value="%2$s">%3$s',
 			'republication_tracker_tool_analytics_id',
-			esc_html( $content )
+			esc_html( $content ),
+			wp_kses_post( '<p><em>' . __( 'Your Google Analytics Universal Analytics ID. Note that <a href="https://support.google.com/analytics/answer/11583528">this will be deprecated on July 1, 2023</a>, so add a GA4 ID and API secret below to avoid interruptions in analytics tracking.', 'republication-tracker-tool' ) . '</em></p>' )
+		);
+	}
+
+	public function republication_tracker_tool_analytics_ga4_id_callback() {
+		$content = get_option( 'republication_tracker_tool_analytics_ga4_id' );
+		echo sprintf(
+			'<input type="text" name="%1$s" value="%2$s">%3$s',
+			'republication_tracker_tool_analytics_ga4_id',
+			esc_html( $content ),
+			wp_kses_post( '<p><em>' . __( 'Your Google Analytics 4 tag ID. <a href="https://support.google.com/analytics/answer/9539598">How to get this</a>.', 'republication-tracker-tool' ) . '</em></p>' )
+		);
+	}
+
+	public function republication_tracker_tool_analytics_ga4_secret_callback() {
+		$content = get_option( 'republication_tracker_tool_analytics_ga4_secret' );
+		echo sprintf(
+			'<input type="text" name="%1$s" value="%2$s">%3$s',
+			'republication_tracker_tool_analytics_ga4_secret',
+			esc_html( $content ),
+			wp_kses_post( '<p><em>' . __( 'Your Google Analytics 4 API secret. <a href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag">How to get this</a>.', 'republication-tracker-tool' ) . '</em></p>' )
 		);
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -154,7 +154,7 @@ class Republication_Tracker_Tool_Settings {
 			'<input type="text" name="%1$s" value="%2$s">%3$s',
 			'republication_tracker_tool_analytics_ga4_secret',
 			esc_html( $content ),
-			wp_kses_post( '<p><em>' . __( 'Your Google Analytics 4 API secret. <a href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag">How to get this</a>.', 'republication-tracker-tool' ) . '</em></p>' )
+			wp_kses_post( '<p><em>' . __( 'Your Google Analytics 4 API secret. <a href="https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#required_parameters">How to get this</a>.', 'republication-tracker-tool' ) . '</em></p>' )
 		);
 	}
 

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -1,17 +1,22 @@
 <?php
 
-// function to get the title of the referring url
-function wprtt_get_referring_page_title( $url ) {
+/**
+ * Function to get the title of the referring url.
+ *
+ * @param string $url URL of the referrer.
+ * @param int    $post_id ID of the shared post.
+ * @return string|void Title of the referring URL, or void if we can't find it.
+ */
+function wprtt_get_referring_page_title( $url, $post_id ) {
+	$response = \wp_remote_get( $url );
 
-	$response = wp_remote_get( $url );
-
-	// if there was no issue grabbing the url, continue
+	// if there was no issue grabbing the url, continue.
 	if ( ! is_wp_error( $response ) ) {
 
-		// find the title element inside of the response body
+		// find the title element inside of the response body.
 		$response = preg_match( '/<title.[^>]*>(.*)<\/title>/siU', $response['body'], $title_matches );
 
-		// if a title element was found, let's get the text from it
+		// if a title element was found, let's get the text from it.
 		if ( $title_matches ) {
 
 			// clean up title: remove EOL's and excessive whitespace.
@@ -19,39 +24,57 @@ function wprtt_get_referring_page_title( $url ) {
 			$title = trim( $title );
 			$title = rawurlencode( $title );
 
-			// return our found title
-			return $title;
+			// return our found title.
+			return urldecode( $title );
 
-			// if there were no title matches found, don't continue
 		} else {
 
-			return;
+			// if there were no title matches found, use the original post title.
+			return \get_the_title( $post_id );
 
 		}
 	}
+}
 
+/**
+ * Extracts the Client ID from the _ga cookie
+ *
+ * @return ?string
+ */
+function wprtt_extract_cid_from_cookies() {
+	if ( isset( $_COOKIE['_ga'] ) ) {
+		$cookie_pieces = explode( '.', $_COOKIE['_ga'], 3 ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( 1 === count( $cookie_pieces ) ) {
+			$cid = reset( $cookie_pieces );
+		} else {
+			list( $version, $domain_depth, $cid ) = $cookie_pieces;
+		}
+		return $cid;
+	}
 }
 
 if ( isset( $_GET['post'] ) ) {
 
-	// set up all of our post vars we want to track
-	$shared_post_id = absint( $_GET['post'] );
-	$shared_post    = get_post( $shared_post_id );
+	// set up all of our post vars we want to track.
+	$shared_post_id = \absint( $_GET['post'] );
+	$shared_post    = \get_post( $shared_post_id );
 
 	$shared_post_slug      = rawurlencode( $shared_post->post_name );
-	$shared_post_permalink = get_permalink( $shared_post_id );
+	$shared_post_permalink = \get_permalink( $shared_post_id );
+
+	error_log( 'derrick test' );
 
 	if ( array_key_exists( 'HTTP_REFERER', $_SERVER ) ) {
+		error_log( $_SERVER['HTTP_REFERER'] );
 
 		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
-			$url = esc_url_raw( $_SERVER['HTTP_REFERER'] );
+			$url = \esc_url_raw( $_SERVER['HTTP_REFERER'] );
 		}
 
-		$url_title = wprtt_get_referring_page_title( $url );
-		$url_title = str_replace( ' ', '%20', $url_title );
+		$url_title = \wprtt_get_referring_page_title( $url, $shared_post_id );
 
-		$url_host = parse_url( $url, PHP_URL_HOST );
-		$url_path = parse_url( $url, PHP_URL_PATH );
+		$url_host = \wp_parse_url( $url, PHP_URL_HOST );
+		$url_path = \wp_parse_url( $url, PHP_URL_PATH );
 
 	} else {
 
@@ -66,7 +89,7 @@ if ( isset( $_GET['post'] ) ) {
 		exit;
 	}
 
-	$value = get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );
+	$value = \get_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', true );
 	if ( $value ) {
 		if ( isset( $value[ $url ] ) ) {
 			$value[ $url ]++;
@@ -78,18 +101,19 @@ if ( isset( $_GET['post'] ) ) {
 			$url => 1,
 		);
 	}
-	$update = update_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', $value );
+	$update = \update_post_meta( $shared_post_id, 'republication_tracker_tool_sharing', $value );
 
-	// if our google analytics tag is set, let's push data to it
-	if ( isset( $_GET['ga'] ) && ! empty( $_GET['ga'] ) ) {
+	// if our google analytics UA tag is set, let's push data to it.
+	// TODO: Deprecate this after UA goes away.
+	if ( isset( $_GET['ga3'] ) && ! empty( $_GET['ga3'] ) ) {
 
-		// our base url to ping GA at
+		// our base url to ping GA at.
 		$analytics_ping_url = 'https://www.google-analytics.com/collect?v=1';
 
-		// create all of our necessary params to track
-		// the docs for these params can be found at: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
+		// create all of our necessary params to track.
+		// the docs for these params can be found at: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters.
 		$analytics_ping_params = array(
-			'tid' => sanitize_text_field( $_GET['ga'] ), // Tracking ID/ Web Property ID.
+			'tid' => \sanitize_text_field( $_GET['ga3'] ), // Tracking ID/ Web Property ID.
 			'cid' => '555', // Client ID.
 			't'   => 'pageview', // Hit type.
 			'dl'  => $shared_post_permalink, // Document location URL.
@@ -102,11 +126,47 @@ if ( isset( $_GET['post'] ) ) {
 			'av'  => 'Republication Tracker v1', // Application Version.
 		);
 
-		// create query based on our params array
+		// create query based on our params array.
 		$analytics_ping_params = http_build_query( $analytics_ping_params );
 
-		$response = wp_remote_post( $analytics_ping_url . '&' . $analytics_ping_params );
+		$response = \wp_remote_post( $analytics_ping_url . '&' . $analytics_ping_params );
+	}
 
+	// If we have the proper GA4 info, let's push to that, too.
+	// We need both a Measurement ID and an API secret for GA4.
+	// https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#required_parameters.
+	$ga4_id     = \get_option( 'republication_tracker_tool_analytics_ga4_id' );
+	$ga4_secret = \get_option( 'republication_tracker_tool_analytics_ga4_secret', false );
+
+	if ( $ga4_id && $ga4_secret && isset( $_GET['ga4'] ) && $_GET['ga4'] === $ga4_id ) {
+		$base_url = \add_query_arg(
+			[
+				'api_secret'     => $ga4_secret,
+				'measurement_id' => $ga4_id,
+			],
+			'https://www.google-analytics.com/mp/collect'
+		);
+		$payload  = [
+			'client_id' => wprtt_extract_cid_from_cookies(),
+			'events'    => [
+				[
+					'name'   => 'page_view',
+					// Params for page_view events: https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag.
+					'params' => [
+						'page_title'    => $url_title,
+						'page_location' => $shared_post_permalink,
+						'page_referrer' => $url,
+					],
+				],
+			],
+		];
+
+		\wp_remote_post(
+			$base_url,
+			[
+				'body' => wp_json_encode( $payload ),
+			]
+		);
 	}
 }
 

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -62,11 +62,7 @@ if ( isset( $_GET['post'] ) ) {
 	$shared_post_slug      = rawurlencode( $shared_post->post_name );
 	$shared_post_permalink = \get_permalink( $shared_post_id );
 
-	error_log( 'derrick test' );
-
 	if ( array_key_exists( 'HTTP_REFERER', $_SERVER ) ) {
-		error_log( $_SERVER['HTTP_REFERER'] );
-
 		if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
 			$url = \esc_url_raw( $_SERVER['HTTP_REFERER'] );
 		}

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -133,7 +133,7 @@ final class Republication_Tracker_Tool {
 			'template_include',
 			function( $template ) {
 				// if the params are set, use our pixel functions
-				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && isset( $_GET['ga'] ) ) {
+				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && ( isset( $_GET['ga3'] ) || isset( $_GET['ga4'] ) ) ) {
 					return include_once plugin_dir_path( __FILE__ ) . 'includes/pixel.php';
 					// else, continue with whatever template was being loaded
 				} else {
@@ -203,13 +203,15 @@ final class Republication_Tracker_Tool {
 	 * @param $post_id Id of the post to track.
 	 */
 	public static function create_tracking_pixel_markup( $post_id ) {
-		$analytics_id = get_option( 'republication_tracker_tool_analytics_id' );
+		$ga3_id = \get_option( 'republication_tracker_tool_analytics_id' );
+		$ga4_id = \get_option( 'republication_tracker_tool_analytics_ga4_id' );
 		return sprintf(
 			// %1$s is the javascript source, %2$s is the post ID, %3$s is the plugins URL
-			'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s" style="width:1px;height:1px;">',
+			'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s%3$s%4$s" style="width:1px;height:1px;">',
 			esc_attr( get_site_url() ),
 			esc_attr( $post_id ),
-			esc_attr( $analytics_id )
+			$ga3_id ? esc_attr( '&ga3=' . $ga3_id ) : '',
+			$ga4_id ? esc_attr( '&ga4=' . $ga4_id ) : ''
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds GA4 support for the tracking pixel. Also updates the README and bumps the "Tested up to" tag to WP 6.2 for the WP.org plugin repository.

Closes `https://app.asana.com/0/1200550061930446/1204364074266317`.

### How to test the changes in this Pull Request:

1. Check out this branch. Go to WP admin > Settings > Reading and find the Republication Tracker Tool section.
2. Confirm that instead of a single "Google Analytics ID" field, there are now three fields:
  - **Google Analytics UA ID:** This is the former "Google Analytics ID", now labeled more specifically and with help text describing its imminent deprecation. If your plugin had this field filled out before, the value should remain.
  - **Google Analytics 4 ID:** This is the GA4 measurement ID. Fill this out with a GA4 measurement ID. Fill this in and follow the help text link if you don't know how to obtain.
  - **Google Analytics 4 API Secret:** API Secret for the GA4 measurement ID. Fill this in and follow the help text link if you don't know how to obtain.

<img width="1422" alt="Screen Shot 2023-05-01 at 2 37 08 PM" src="https://user-images.githubusercontent.com/2230142/235526749-383800a3-72a9-4a6c-8596-6bc68d62ea1d.png">

3. Save the settings with your new GA4 credentials.
4. Using the Republication Tracker Tool widget, copy the HTML for an article and share it to a different site (if pasting into a WP site, make sure to paste in code editor mode or into an HTML block so that the pixel doesn't get stripped). Ensure that the content contains a tracking pixel at the end with a `ga3` (if you filled out the UA ID field in settings) and a `ga4` param matching your GA4 ID in plugin settings.
5. View the shared article front-end. In Dev Tools > Network tab, confirm you see a GET request to your pixel—should be the original post's domain with `/?republication-pixel=true&post=[POST ID]&ga4=[GA4 MEASUREMENT ID]` params.
6. In the Google Analytics dashboard, open your GA4 property and go to Realtime. 
7. Confirm that you see a pageview event for viewing the shared content. Click on the event, then **Page Referrer**, and confirm that the referrer matches the domain of the second site you shared to.

<img width="312" alt="Screen Shot 2023-05-01 at 2 40 59 PM" src="https://user-images.githubusercontent.com/2230142/235527538-ee0a8ba8-abcb-42e0-aabe-da25ea783323.png">
