### PR TITLE
fix: support old "ga" param for GA3 tracking

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -101,10 +101,10 @@ if ( isset( $_GET['post'] ) ) {
 
 	// if our google analytics UA tag is set, let's push data to it.
 	// TODO: Deprecate this after UA goes away.
-	if ( ( isset( $_GET['ga'] ) && ! empty( $_GET['ga'] ) ) || ( isset( $_GET['ga3'] ) && ! empty( $_GET['ga3'] ) ) ) {
+	if ( ! empty( $_GET['ga'] ) || ! empty( $_GET['ga3'] ) ) {
 
 		// ID can be in a 'ga' (legacy) or 'ga3' (current) param.
-		$ga3_id = isset( $_GET['ga3'] ) ? $_GET['ga3'] : $_GET['ga'];
+		$ga3_id = ! empty( $_GET['ga3'] ) ? $_GET['ga3'] : $_GET['ga'];
 
 		// our base url to ping GA at.
 		$analytics_ping_url = 'https://www.google-analytics.com/collect?v=1';

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -101,7 +101,10 @@ if ( isset( $_GET['post'] ) ) {
 
 	// if our google analytics UA tag is set, let's push data to it.
 	// TODO: Deprecate this after UA goes away.
-	if ( isset( $_GET['ga3'] ) && ! empty( $_GET['ga3'] ) ) {
+	if ( ( isset( $_GET['ga'] ) && ! empty( $_GET['ga'] ) ) || ( isset( $_GET['ga3'] ) && ! empty( $_GET['ga3'] ) ) ) {
+
+		// ID can be in a 'ga' (legacy) or 'ga3' (current) param.
+		$ga3_id = isset( $_GET['ga3'] ) ? $_GET['ga3'] : $_GET['ga'];
 
 		// our base url to ping GA at.
 		$analytics_ping_url = 'https://www.google-analytics.com/collect?v=1';
@@ -109,7 +112,7 @@ if ( isset( $_GET['post'] ) ) {
 		// create all of our necessary params to track.
 		// the docs for these params can be found at: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters.
 		$analytics_ping_params = array(
-			'tid' => \sanitize_text_field( $_GET['ga3'] ), // Tracking ID/ Web Property ID.
+			'tid' => \sanitize_text_field( $ga3_id ), // Tracking ID/ Web Property ID.
 			'cid' => '555', // Client ID.
 			't'   => 'pageview', // Hit type.
 			'dl'  => $shared_post_permalink, // Document location URL.

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -133,7 +133,7 @@ final class Republication_Tracker_Tool {
 			'template_include',
 			function( $template ) {
 				// if the params are set, use our pixel functions
-				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && ( isset( $_GET['ga3'] ) || isset( $_GET['ga4'] ) ) ) {
+				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && ( isset( $_GET['ga'] ) || isset( $_GET['ga3'] ) || isset( $_GET['ga4'] ) ) ) {
 					return include_once plugin_dir_path( __FILE__ ) . 'includes/pixel.php';
 					// else, continue with whatever template was being loaded
 				} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#183 introduced support for GA4 tracking pixels in addition to GA3. In that PR we changed the URL param for GA3 ID from `ga` to `ga3`, for clarity. However, this will break functionality for content that has already been shared prior to this change. This PR restores support for the plain `ga` param and treats it the same as the new `ga3` param, to avoid feature regression for this legacy content.

### How to test the changes in this Pull Request:

1. On `master`, copy the HTML for a post but replace all instances of `ga3` with `ga`.
2. Share this modified HTML to another site.
3. View the shared content's front-end.
4. In your GA3 dashboard > Realtime, observe that pageviews of the shared content are not tracked.
5. Check out this branch and re-view the shared content.
6. This time confirm that it is tracked.
