### PR TITLE
fix: create fallback client id for GA if none exists

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -42,7 +42,7 @@ function wprtt_get_referring_page_title( $url, $post_id ) {
  * @return string Randomly generated client ID.
  */
 function wprtt_create_cid_cookie_if_not_set() {
-	$cid = \wp_rand( 100000000, 999999999 );
+	$cid = (string) \wp_rand( 100000000, 999999999 );
 
 	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 	setcookie( 'newspack-cid', $cid, time() + 30 * DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true );

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -37,6 +37,20 @@ function wprtt_get_referring_page_title( $url, $post_id ) {
 }
 
 /**
+ * Generate a random client ID string and set the newspack-cid fallback cookie if not set.
+ *
+ * @return string Randomly generated client ID.
+ */
+function wprtt_create_cid_cookie_if_not_set() {
+	$cid = \wp_rand( 100000000, 999999999 );
+
+	// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+	setcookie( 'newspack-cid', $cid, time() + 30 * DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, true );
+
+	return $cid;
+}
+
+/**
  * Extracts the Client ID from the _ga cookie
  *
  * @return ?string
@@ -51,6 +65,12 @@ function wprtt_extract_cid_from_cookies() {
 		}
 		return $cid;
 	}
+
+	if ( isset( $_COOKIE['newspack-cid'] ) ) {
+		return $_COOKIE['newspack-cid'];
+	}
+
+	return wprtt_create_cid_cookie_if_not_set();
 }
 
 if ( isset( $_GET['post'] ) ) {

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -191,6 +191,8 @@ final class Republication_Tracker_Tool {
 
 		$vars[] .= 'republication-pixel';
 		$vars[] .= 'GA';
+		$vars[] .= 'ga3';
+		$vars[] .= 'ga4';
 		$vars[] .= 'post';
 
 		return $vars;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

GA4 events require a `client_id` param. This plugin attempts to extract it from the `_ga` cookie if set, but occasionally this cookie can't be fetched or hasn't been set yet (possibly due to server-level caching). This PR creates a fallback that first looks for the `newspack-cid` cookie (which is the fallback client ID set for Newspack Campaigns and Reader Activation features) and if that can't be fetched either, generates a random 9-digit string and attempts to store that as a `newspack-cid` cookie so the ID can be fetched in future requests in the same session.

### How to test the changes in this Pull Request:

Kind of hard to know how to replicate the scenario where `$_COOKIES` will be empty, but open your GA dashboard's Real Time events report and ensure that viewing shared content always results in a `page_view` event with the correct params.