### PR TITLE
Accessibility improvements to republication modal

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -104,6 +104,10 @@
 }
 
 .republication-tracker-tool-close {
+  background: transparent !important;
+  border: 0 !important;
+  color: #000 !important;
+  padding: 0.5em !important;
   position: absolute;
   top: 0;
   right: 0.5em;

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -1,9 +1,10 @@
-function copyToClipboard( element ) {
+function copyToClipboard( element, button ) {
 	var $temp = jQuery( '<input>' );
 	jQuery( 'body' ).append( $temp );
 	$temp.val( jQuery( element ).text() ).select();
 	document.execCommand( 'copy' );
 	$temp.remove();
+	button.focus();
 }
 
 function modal_actions(){
@@ -22,7 +23,6 @@ function modal_actions(){
 	var $modal = $('#republication-tracker-tool-modal');
 	var $btn = $('.republication-tracker-tool-button');
 	var $close = $('.republication-tracker-tool-close');
-	var $copy = $( '#republication-copy-to-clipboard' );
 
 	// url hash of #show-republish: open the modal
 	if ( '#show-republish' === window.location.hash ) {

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -22,36 +22,37 @@ function modal_actions(){
 	var $modal = $('#republication-tracker-tool-modal');
 	var $btn = $('.republication-tracker-tool-button');
 	var $close = $('.republication-tracker-tool-close');
+	var $copy = $( '#republication-copy-to-clipboard' );
 
 	// url hash of #show-republish: open the modal
 	if ( '#show-republish' === window.location.hash ) {
-		show_modal( $modal );
+		show_modal( $modal, $close );
 	}
 
 	// click the republish button: open the modal
 	$btn.click(function(){
-		show_modal( $modal );
+		show_modal( $modal, $close );
 	});
 
 	// click on the modal: close the modal
 	$modal.click(function(){
-		close_modal( $modal );
+		close_modal( $modal, $btn );
 	});
 
 	// close button click: close the modal
 	$close.click(function(){
-		close_modal( $modal );
+		close_modal( $modal, $btn );
 	});
 
 	// escape key press: close the modal
 	$(document).keyup(function(e) {
 		if (27 === e.keyCode) {
-			close_modal( $modal );
+			close_modal( $modal, $btn );
 		}
 	});
 }
 
-function show_modal( $modal ) {
+function show_modal( $modal, $close ) {
 	var $ = jQuery;
 	var $modal_content = $('#republication-tracker-tool-modal-content');
 	//$modal.html( html );
@@ -61,12 +62,41 @@ function show_modal( $modal ) {
 	$('#republication-tracker-tool-modal-content').unbind().click(function(e) {
 		e.stopPropagation();
 	});
+	trapFocus( $modal );
+	$close.focus();
 }
 
-function close_modal( $modal ) {
+function trapFocus( $modal ) {
+	var $ = jQuery;
+	var focusableEls = $modal.find('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])');
+	var firstFocusableEl = focusableEls[0];
+	var lastFocusableEl = focusableEls[focusableEls.length - 1];
+	var KEYCODE_TAB = 9;
+
+	$modal.on( 'keydown', function( e ) {
+		var isTabPressed = ( e.key === 'Tab' || e.keyCode === KEYCODE_TAB );
+
+		if ( ! isTabPressed ) {
+			return;
+		}
+
+		if ( e.shiftKey ) /* shift + tab */ {
+			if ( document.activeElement === firstFocusableEl ) {
+				lastFocusableEl.focus();
+				e.preventDefault();
+			}
+		} else if ( document.activeElement === lastFocusableEl ) {
+			firstFocusableEl.focus();
+			e.preventDefault();
+		}
+	} );
+}
+
+function close_modal( $modal, $btn ) {
 	var $ = jQuery;
 	$('body').removeClass('modal-open-disallow-scrolling');
 	$modal.hide();
+	$btn.focus();
 }
 
 jQuery(document).ready(function(){

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -93,13 +93,13 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 			if ( $is_amp ) {
 				?>
-					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay" role="dialog" aria-modal="true">
+					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay" role="dialog" aria-modal="true" aria-labelledby="republish-modal-label">
 						<?php echo esc_html( include_once $modal_content_path ); ?>
 					</amp-lightbox>
 				<?php
 			} else {
 				?>
-					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>" role="dialog" aria-modal="true">
+					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>" role="dialog" aria-modal="true" aria-labelledby="republish-modal-label">
 						<?php echo esc_html( include_once $modal_content_path ); ?>
 					</div>
 				<?php

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -137,7 +137,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			);
 			if ( ! $is_amp ) {
 				?>
-			<button id="republication-copy-to-clipboard" onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content', this)"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 				<?php
 			}
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -100,9 +100,9 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
-	echo '<div ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
-	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></div>';
-	echo sprintf( '<h2>%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
+	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
+	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
+	echo sprintf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
@@ -137,7 +137,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			);
 			if ( ! $is_amp ) {
 				?>
-			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+			<button id="republication-copy-to-clipboard" onclick="copyToClipboard('#republication-tracker-tool-shareable-content')"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 				<?php
 			}
 


### PR DESCRIPTION
This PR adds a number of accessibility improvements to the republication tracker modal:

* It adds an `aria-labelledby` attribute to the modal, and uses the existing modal header as a reference.
* It changes the close button to an actual button (and adds some general override styles so it should appear the same as it does now). 
* When the modal is opened, it moves the keyboard focus to the 'Close' button.
* When you tab through the modal, it traps focus inside of the modal (so when you get to the copy key and tab further, it kicks you back to the close button, instead of letting you tab outside and behind of the modal). 
* When you copy the content using the keyboard (focus on the button and hit enter), the button retains focus.

See 200133283613421-as-1206162676524753

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Set up the republication widget on a single story.
3. Confirm it works as usual when navigating via mouse (you can open the modal, close the modal, and copy the story content).
4. Navigate the story via keyboard: tab to the 'Republish this Story' button, and hit the Enter key to open the modal.
5. Confirm that the Close button gets focus when the modal is opened. 
6. Tab through all the elements in the modal; confirm when you get to the bottom, continuing to tab loops you back to the top.
7. Tab to the 'Copy' button and hit 'Enter'; confirm that focus remains on the button.
8. Confirm you can tab back to the Close Button (either Shift+Tab, or regular Tab to loop back to it), and hit Enter to close the window.
9. Confirm that the keyboard focus is returned to the Republish this story button when the modal is closed.
10. Confirm that the contents of the story were copied to your clipboard (you can do this by trying to paste them into a text editor). 
