### PR TITLE
fix: update enqueued files to use filemtime to enable proper caching

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -53,9 +53,9 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		$is_amp = self::is_amp();
 
 		if ( ! $is_amp ) {
-			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), Republication_Tracker_Tool::VERSION, false );
+			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
 		}
-		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), Republication_Tracker_Tool::VERSION );
+		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), filemtime( plugin_dir_path(__FILE__) ) );
 
 		echo wp_kses_post( $args['before_widget'] );
 

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -24,14 +24,6 @@ require plugin_dir_path( __FILE__ ) . 'includes/compatibility-co-authors-plus.ph
 final class Republication_Tracker_Tool {
 
 	/**
-	 * Current version.
-	 *
-	 * @var    string
-	 * @since  1.0
-	 */
-	const VERSION = '1.0.1';
-
-	/**
 	 * URL of plugin directory.
 	 *
 	 * @var    string


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This plugin was appending a static version number to enqueued JavaScript and CSS; this number wasn't getting updated with each release, though, so the files would be cached after updates.

I replaced the version number with `filemtime` instead.

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. View the source and confirm a `ver` query string and value is being added to the paths enqueuing the plugin's CSS and JS files, like `?ver=1704225350`.

