### PR TITLE
[#203]  Separate Page for Republicating Articles

### DIFF
--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -1,8 +1,19 @@
 .republish-article__content {
 	grid-gap: 2rem;
-	display: grid;
-	grid-template-columns: 1fr 1fr;
+	display: flex;
+	gap: 2rem;
 	margin-top: 2rem;
+}
+
+.republish-article__license,
+.republish-article__info {
+	flex: 1;
+}
+
+@media (max-width: 768px) {
+	.republish-article__content {
+		flex-direction: column;
+	}
 }
 
 .republish-article__info textarea {

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -1,0 +1,23 @@
+.republish-article__content {
+	grid-gap: 2rem;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	margin-top: 2rem;
+}
+
+.republish-article__info textarea {
+	border: 2px solid #c7c7c7;
+	height: 50vh;
+	line-height: 1.6em;
+	overflow: scroll;
+	padding: 16px;
+}
+
+.republish-article__info textarea:focus {
+	border-color: #a7a7a7;
+	box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.2);
+}
+
+.republish-article__copy-button {
+	margin-top: 20px;
+}

--- a/assets/republish-template.js
+++ b/assets/republish-template.js
@@ -1,0 +1,62 @@
+/**
+ * Republish template script.
+ */
+
+/**
+ * The main script for the republish template.
+ */
+document.addEventListener("DOMContentLoaded", () => {
+	/**
+	 * Selects the text in the textarea when it is focused.
+	 */
+	document
+		.querySelector(".republish-article .republish-article__info textarea")
+		?.addEventListener("focus", (event) => {
+			event.target.select();
+		});
+
+	/**
+	 * Copies the text in the textarea to the clipboard when the copy button is clicked.
+	 */
+	document
+		.querySelector(".republish-article .republish-article__copy-button")
+		?.addEventListener("click", (event) => {
+			event.preventDefault();
+			const textarea = document.querySelector(
+				".republish-article .republish-article__info textarea"
+			);
+			const success = copyTextToClipboard(textarea.value);
+
+			if (success) {
+				event.target.innerText = __("Copied!", "the-city-features");
+
+				setTimeout(() => {
+					event.target.innerText = __(
+						"Copy to clipboard",
+						"the-city-features"
+					);
+				}, 2000);
+			}
+		});
+
+	/**
+	 * Copies the given text to the clipboard.
+	 *
+	 * @param {string} text The text to copy to the clipboard.
+	 *
+	 * @return {boolean} True if the text was copied to the clipboard, false otherwise.
+	 */
+	const copyTextToClipboard = (text) => {
+		// Check if the clipboard API is available.
+		if (!navigator.clipboard) {
+			return false;
+		}
+		// Copy the text to the clipboard.
+		navigator.clipboard
+			.writeText(text)
+			.then(() => true)
+			.catch(() => false);
+
+		return true;
+	};
+});

--- a/includes/class-republication-rewrite.php
+++ b/includes/class-republication-rewrite.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Republication Tracker Tool Rewrite Endpoint.
+ *
+ * @since 1.6.0
+ *
+ * @package Republication_Tracker_Tool
+ */
+
+/**
+ * Republication Tracker Tool Rewrite Endpoint class.
+ *
+ * @since 1.6.0
+ */
+class Republication_Tracker_Tool_Rewrite_Endpoint {
+
+	/**
+	 * Rewrite endpoint.
+	 *
+	 * @var string
+	 */
+	public const ENDPOINT = 'republish';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		add_action( 'init', array( $this, 'register_endpoint' ) );
+		add_filter( 'template_include', array( $this, 'filter_template_include' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts_and_styles' ) );
+	}
+
+	/**
+	 * Register endpoint.
+	 */
+	public function register_endpoint() {
+
+		$endpoint = apply_filters( 'republication_tracker_tool_endpoint', self::ENDPOINT );
+
+		// Add rewrite rule to handle /republish/<wordpress-post-url>.
+		add_rewrite_rule(
+			sprintf( '^%s/(.+)', $endpoint ),
+			sprintf( 'index.php?%s=$matches[1]', $endpoint ),
+			'top'
+		);
+
+		add_rewrite_tag( sprintf( '%%%s%%', $endpoint ), '([^/]+)' );
+	}
+
+	/**
+	 * Filter template include.
+	 *
+	 * @param string $template Template.
+	 */
+	public function filter_template_include( $template ) {
+
+		$rewrite_endpoint = apply_filters( 'republication_tracker_tool_endpoint', self::ENDPOINT );
+
+		$endpoint = get_query_var( $rewrite_endpoint );
+
+		if ( empty( $endpoint ) ) {
+			return $template;
+		}
+
+		// Get the name of the custom template file.
+		$republish_template = REPUBLICATION_TRACKER_TOOL_PATH . 'templates/republish-template.php';
+
+		// Get the post ID from the endpoint.
+		$post_id = null;
+
+		// Check if the VIP URL to post ID function exists.
+		if ( function_exists( 'wpcom_vip_url_to_postid' ) ) {
+			$post_id = wpcom_vip_url_to_postid( $endpoint );
+		} else {
+			$post_id = url_to_postid( $endpoint );
+		}
+
+		// If there is no post ID then redirect to 404.
+		if ( ! $post_id ) {
+			global $wp_query;
+			$wp_query->set_404();
+			status_header( 404 );
+			nocache_headers();
+			include get_query_template( '404' );
+			exit;
+		}
+
+		// Check if the republish widget is disabled for the post.
+		$is_republish_disabled = get_post_meta( $post_id, 'republication-tracker-tool-hide-widget', true );
+
+		// If the republish widget is disabled, redirect to the post.
+		if ( ! empty( $is_republish_disabled ) ) {
+			wp_safe_redirect( get_permalink( $post_id ) );
+
+			exit;
+		}
+
+		$post_type = get_post_type( $post_id );
+
+		$republish_post_types = apply_filters( 'republication_tracker_tool_post_types', array( 'post' ) );
+
+		// If the post type is not in the republish post types, redirect to the post.
+		if ( ! in_array( $post_type, $republish_post_types, true ) ) {
+			wp_safe_redirect( get_permalink( $post_id ) );
+
+			exit;
+		}
+
+		// If the republish template file and post ID exists, use it; otherwise, fall back to the default template.
+		if ( file_exists( $republish_template ) && $post_id ) {
+
+			// Set the post ID.
+			set_query_var( 'republish_post_id', $post_id );
+
+			// Add canonical URL and noindex to the page.
+			add_action(
+				'wp_head',
+				static function () use ( $post_id ) {
+					$canonical_url = get_permalink( $post_id );
+					echo wp_sprintf( '<link rel="canonical" href="%s" />', esc_url( $canonical_url ) );
+					echo '<meta name="robots" content="noindex, nofollow" />';
+				},
+				1
+			);
+
+			// Return the republish template.
+			return $republish_template;
+		}
+
+		return $template; // Return the original template for other requests.
+	}
+
+	/**
+	 * Check if the current page is a republish page.
+	 *
+	 * @return bool Whether the current page is a republish page.
+	 */
+	public function is_republish_page() {
+		// Get the value of the republish query variable.
+		$republish_var = get_query_var( 'republish_post_id' );
+
+		// Check if the republish variable is set and not empty.
+		return ! empty( $republish_var );
+	}
+
+	/**
+	 * Enqueue scripts and styles for the republish page.
+	 */
+	public function enqueue_scripts_and_styles() {
+
+		if ( ! $this->is_republish_page() ) {
+			return;
+		}
+
+		// Enqueue the republish page styles.
+		wp_enqueue_style(
+			'republication-tracker-tool-republish-template',
+			REPUBLICATION_TRACKER_TOOL_URL . 'assets/republish-template.css',
+			array(),
+			REPUBLICATION_TRACKER_TOOL_VERSION
+		);
+
+		// Enqueue the republish page scripts.
+		wp_enqueue_script(
+			'republication-tracker-tool-republish-template',
+			REPUBLICATION_TRACKER_TOOL_URL . 'assets/republish-template.js',
+			array(),
+			REPUBLICATION_TRACKER_TOOL_VERSION,
+			true
+		);
+	}
+}

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -28,6 +28,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-widget.php';
 require plugin_dir_path( __FILE__ ) . 'includes/compatibility-co-authors-plus.php';
+require plugin_dir_path( __FILE__ ) . 'includes/class-republication-rewrite.php';
 
 /**
 * Main initiation class.
@@ -75,6 +76,22 @@ final class Republication_Tracker_Tool {
 	 * @var Republication_Tracker_Tool_Settings
 	 */
 	protected $settings;
+
+	/**
+	 * Instance of Republication_Tracker_Tool_Article_Settings
+	 *
+	 * @since 1.0
+	 * @var Republication_Tracker_Tool_Article_Settings
+	 */
+	protected $article_settings;
+
+	/**
+	 * Instance of Republication_Tracker_Tool_Rewrite_Endpoint
+	 *
+	 * @since 1.6.0
+	 * @var Republication_Tracker_Tool_Rewrite_Endpoint
+	 */
+	protected $rewrite_endpoint;
 
 	/**
 	 * Creates or returns an instance of this class.
@@ -126,6 +143,7 @@ final class Republication_Tracker_Tool {
 
 		$this->settings         = new Republication_Tracker_Tool_Settings( $this );
 		$this->article_settings = new Republication_Tracker_Tool_Article_Settings( $this );
+		$this->rewrite_endpoint = new Republication_Tracker_Tool_Rewrite_Endpoint();
 
 		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
 

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -11,6 +11,19 @@
  * @package         Republication_Tracker_Tool
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Define plugin constants.
+function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
+$plugin_data = get_plugin_data( __FILE__, false, false );
+
+define( 'REPUBLICATION_TRACKER_TOOL_VERSION', $plugin_data['Version'] );
+define( 'REPUBLICATION_TRACKER_TOOL_URL', plugin_dir_url( __FILE__ ) );
+define( 'REPUBLICATION_TRACKER_TOOL_PATH', plugin_dir_path( __FILE__ ) );
+
 require plugin_dir_path( __FILE__ ) . 'includes/class-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-widget.php';

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Republish page template.
+ *
+ * @since 1.6.0
+ *
+ * @package Republication_Tracker_Tool
+ */
+
+use Newspack\Newspack_Image_Credits;
+
+get_header();
+
+global $allowedposttags;
+$allowed_tags_excerpt = $allowedposttags;
+unset( $allowed_tags_excerpt['form'] );
+
+/**
+ * Allow sites to configure which tags are allowed to be output in the republication content
+ *
+ * Default value is the standard global $allowedposttags, except form elements.
+ *
+ * @link https://github.com/Automattic/republication-tracker-tool/issues/49
+ * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
+ *
+ * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
+ */
+$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt, $post );
+
+// Get post ID from query var.
+$republish_post_id = get_query_var( 'republish_post_id' );
+
+// Get post object.
+$post_object = get_post( $republish_post_id );
+
+$content = $post_object->post_content;
+
+// Remove shortcodes.
+$content = strip_shortcodes( $content );
+
+// Remove comments from content.
+$content = preg_replace( '/<!--(.|\s)*?-->/i', '', $content );
+
+// Remove some tags.
+$content = wp_kses( $content, $allowed_tags_excerpt );
+
+// Remove empty paragraphs.
+$content = str_replace( '<p></p>', '', wpautop( $content ) );
+
+// Remove the image if "can distribute" is not set.
+if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+
+	// Find all the attachments id in the content.
+	preg_match_all( '/<img[^>]+class="wp-image-(\d+)"[^>]*>/', $content, $matches );
+	$found_images = array();
+
+	foreach ( $matches[1] as $key => $attachment_id ) {
+		$can_distribute = get_post_meta( $attachment_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
+
+		if ( empty( $can_distribute ) ) {
+			$found_images[ $attachment_id ] = $matches[0][ $key ];
+		}
+	}
+
+	// Suppress the found images if "can distribute" is not set.
+	foreach ( $found_images as $attachment_id => $found_image ) {
+		// Remove the figure and figcaption of $found_image using regex.
+		$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
+		$content = preg_replace( $pattern, '', $content );
+	}
+}
+
+// Apply filters to the content.
+$content = apply_filters( 'republication_tracker_tool_republish_content', $content, $post_object );
+
+// Get the license statement.
+$license_statement = get_option( 'republication_tracker_tool_policy' );
+
+// Article title.
+$article_title = get_the_title( $republish_post_id );
+
+// Get article subtitle.
+$article_subtitle = get_post_meta( $republish_post_id, 'newspack_post_subtitle', true );
+
+// Get article author byline.
+$author_byline = apply_filters( 'republication_tracker_tool_author_byline', '', $republish_post_id );
+
+// Get article date and time in current timezone.
+$article_date_gmt = get_post_time( 'U', true, $republish_post_id ); // Get post date in GMT.
+
+// Convert GMT date to the current timezone.
+$time_zone_string = get_option( 'timezone_string', 'UTC' );
+
+if ( empty( $time_zone_string ) ) {
+	$time_zone_string = 'UTC';
+}
+
+$current_timezone = new DateTimeZone( $time_zone_string ); // Get current timezone.
+$article_date     = new DateTime();
+$article_date->setTimestamp( $article_date_gmt );
+$article_date->setTimezone( $current_timezone );
+$article_date = $article_date->format( 'M j g:ia T' );
+
+// Featured image.
+$featured_image = get_the_post_thumbnail( $republish_post_id, 'full' );
+
+if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+	$featured_media_id             = get_post_thumbnail_id( $republish_post_id );
+	$can_distribute_featured_image = get_post_meta( $featured_media_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
+
+	if ( empty( $can_distribute_featured_image ) ) {
+		$featured_image = '';
+	}
+}
+
+// Canonical URL.
+$canonical_url = get_permalink( $republish_post_id );
+$canonical_tag = sprintf(
+	'<link rel="canonical" href="%s" />',
+	esc_url( $canonical_url )
+);
+
+// Get the content footer.
+$content_footer = Republication_Tracker_Tool::create_content_footer( $post_object );
+
+// Republish content.
+$republish_content = '';
+
+// Add the article title to the republish content.
+if ( ! empty( $article_title ) ) {
+	$republish_content .= sprintf(
+		'<h1>%s</h1>',
+		esc_html( $article_title )
+	);
+}
+
+// Add the article subtitle to the republish content. Retrievable via Newspack's newspack_post_subtitle meta key.
+if ( ! empty( $article_subtitle ) ) {
+	$republish_content .= sprintf(
+		"\n\n<h2>%s</h2>",
+		esc_html( $article_subtitle )
+	);
+}
+
+// Add the article author to the republish content.
+if ( ! empty( $author_byline ) ) {
+	$republish_content .= sprintf(
+		"\n\n<div>%s</div>",
+		$author_byline
+	);
+}
+
+// Add the article date to the republish content.
+if ( ! empty( $article_date ) ) {
+	$republish_content .= sprintf(
+		"\n\n<time>%s</time>",
+		esc_html( $article_date )
+	);
+}
+
+// Add the featured image to the republish content.
+if ( ! empty( $featured_image ) ) {
+	$republish_content .= sprintf(
+		"\n\n%s",
+		$featured_image
+	);
+}
+
+// Add the content to the republish content.
+if ( ! empty( $content ) ) {
+	$republish_content .= sprintf(
+		"\n%s",
+		$content
+	);
+}
+
+// Add the canonical URL to the republish content.
+if ( ! empty( $canonical_tag ) ) {
+	$republish_content .= sprintf(
+		"\n\n%s",
+		$canonical_tag
+	);
+}
+
+// Add the content footer to the republish content.
+if ( ! empty( $content_footer ) ) {
+	$republish_content .= sprintf(
+		"\n\n%s",
+		html_entity_decode( $content_footer )
+	);
+}
+
+// Remove css classes from content.
+$republish_content = preg_replace( '/ class=".*?"/', '', $republish_content );
+
+// Remove srcset attribute from images.
+$republish_content = preg_replace( '/ srcset=".*?"/', '', $republish_content );
+
+// Remove sizes attribute from images.
+$republish_content = preg_replace( '/ sizes=".*?"/', '', $republish_content );
+
+// Filter the republish content.
+$republish_content = apply_filters( 'republication_tracker_tool_republish_article_markup', $republish_content, $post_object );
+?>
+
+<section id="primary" class="content-area">
+		<main class="site-main">
+			<article class="republish-article">
+				<h3><?php esc_html_e( 'Republish this article', 'republication-tracker-tool' ); ?></h3>
+				<h1><?php echo esc_html( $post_object->post_title ); ?></h1>
+				<div class="republish-article__content">
+					<section class="republish-article__license">
+						<?php echo wp_kses_post( $license_statement ); ?>
+					</section>
+					<section class="republish-article__info">
+						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>">
+							<?php echo esc_html( $republish_content ); ?>
+						</textarea>
+						<button class="republish-article__copy-button" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">
+							<?php esc_html_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>
+						</button>
+					</section>
+				</div>
+			</article>
+		</main>
+</section>
+
+<?php
+
+get_footer();

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -33,6 +33,11 @@ $republish_post_id = get_query_var( 'republish_post_id' );
 // Get post object.
 $post_object = get_post( $republish_post_id );
 
+// Check if the post object is valid.
+if ( ! $post_object instanceof WP_Post ) {
+	wp_die( esc_html__( 'Invalid post ID.', 'republication-tracker-tool' ) );
+}
+
 $content = $post_object->post_content;
 
 // Remove shortcodes.

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -209,9 +209,11 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 				<h3><?php esc_html_e( 'Republish this article', 'republication-tracker-tool' ); ?></h3>
 				<h1><?php echo esc_html( $post_object->post_title ); ?></h1>
 				<div class="republish-article__content">
-					<section class="republish-article__license">
-						<?php echo wp_kses_post( $license_statement ); ?>
-					</section>
+					<?php if ( ! empty( $license_statement ) ) : ?>
+						<section class="republish-article__license">
+							<?php echo wp_kses_post( $license_statement ); ?>
+						</section>
+					<?php endif; ?>
 					<section class="republish-article__info">
 						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>">
 							<?php echo esc_html( $republish_content ); ?>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -215,9 +215,7 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 						</section>
 					<?php endif; ?>
 					<section class="republish-article__info">
-						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>">
-							<?php echo esc_html( $republish_content ); ?>
-						</textarea>
+						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>"><?php echo esc_html( $republish_content ); ?></textarea>
 						<button class="republish-article__copy-button" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">
 							<?php esc_html_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>
 						</button>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -213,6 +213,9 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 			<article class="republish-article">
 				<h3><?php esc_html_e( 'Republish this article', 'republication-tracker-tool' ); ?></h3>
 				<h1><?php echo esc_html( $post_object->post_title ); ?></h1>
+
+				<?php do_action( 'republication_tracker_tool_before_republish_content', $post_object ); ?>
+
 				<div class="republish-article__content">
 					<?php if ( ! empty( $license_statement ) ) : ?>
 						<section class="republish-article__license">
@@ -226,6 +229,8 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 						</button>
 					</section>
 				</div>
+
+				<?php do_action( 'republication_tracker_tool_after_republish_content', $post_object ); ?>
 			</article>
 		</main>
 </section>


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This pull request addresses the enhancement of creating a dedicated page for republicating articles as outlined in the issue #203

### Changes Made:
- Modified the article's rewrite endpoint to include the prefix republish, resulting in URLs like https://example.com/republish/<post-url>.
- Implemented redirection to the 404 page for invalid slugs passed in the URL after republish.
- Ensured that the Republication Tracker Tool's meta field, responsible for hiding the Republication Widget, also applies to the Republication Rewrite page. When republication is disabled, users are redirected to the default post template.
- Added canonical links to the original post and included a noindex meta tag on the republication rewrite page to mitigate potential SEO issues.
- Integrated functionality from the Newspack plugin to remove any media from the article that cannot be distributed, if the plugin is active.

<img width="1336" alt="image" src="https://github.com/Automattic/republication-tracker-tool/assets/43412958/94fd61e5-1634-4f03-853b-8840ada935ca">

### WordPress hooks:

#### `republication_tracker_tool_endpoint`

- Filters the republish page template rewrite endpoint.
- Default: `republish`
- `apply_filters( 'republication_tracker_tool_endpoint', string $endpoint );`

#### `republication_tracker_tool_post_types`

- Filters the post types that can be republished
- Default: `array( 'post' )`
- `apply_filters( 'republication_tracker_tool_post_types', array( 'post' ) );`

#### `republication_tracker_tool_republish_content`

- Filters the post content of the republished article.
- Default: Republished article post content
- `apply_filters( 'republication_tracker_tool_republish_content', string $content, WP_Post $post_object );`

#### `republication_tracker_tool_author_byline`

- Filters the author's byline
- Default: `''` Empty string
- `apply_filters( 'republication_tracker_tool_author_byline', '', $republish_post_id );`

#### `republication_tracker_tool_republish_article_markup`

- Filters republish article markup
- Default: Republish article markup
- `apply_filters( 'republication_tracker_tool_republish_article_markup', string $republish_content, WP_Post $post_object );`

#### `republication_tracker_tool_before_republish_content`

- Fires before the republish content page layout
- `do_action( 'republication_tracker_tool_before_republish_content', $post_object );`

#### `republication_tracker_tool_after_republish_content`

- Fires after the republish content page layout
- `do_action( 'republication_tracker_tool_before_republish_content', $post_object );`

### How to Test:
- Enable the Republication Tracker Tool plugin.
- Refresh the permalinks.
- Navigate to an article and attempt to access the republication page using the provided URL format.
- Verify that invalid slugs redirect to the 404 page.
-  Test the hiding functionality of the Republication Widget by toggling the respective meta field and checking the redirection behavior.
- Inspect the source code of the republication rewrite page to confirm the presence of canonical links and the noindex meta tag.
-  If applicable, activate the Newspack plugin and ensure that media not suitable for distribution is removed from republicated articles.

Closes #203
