### PR TITLE
fix: update newspack-scripts to v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "grunt": "~0.4.5",
         "grunt-wp-i18n": "~0.5.0",
         "grunt-wp-readme-to-markdown": "~1.0.0",
-        "newspack-scripts": "^5.3.0"
+        "newspack-scripts": "^5.5.1"
       }
     },
     "node_modules/@automattic/babel-plugin-preserve-i18n": {
@@ -20965,9 +20965,9 @@
       "dev": true
     },
     "node_modules/newspack-scripts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-      "integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+      "integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
       "dev": true,
       "dependencies": {
         "@automattic/calypso-build": "^10.0.0",
@@ -49058,9 +49058,9 @@
       "dev": true
     },
     "newspack-scripts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.3.0.tgz",
-      "integrity": "sha512-rzvctV0e2QCRZOlRNyudCIGOkcK5XiqXZODuqtICDIh+bNyARxCDfpjJZPT1UUTdDXIsM/McH68ItHy3aa08aQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.5.1.tgz",
+      "integrity": "sha512-0M6P1XNpHJ7tRVD3hLpOK8rFEzDzB93EkGweA7Q+HOb4ke+ZjoUmqDl0aBMesvtPA019KsYExIiOWlzs4S6kNg==",
       "dev": true,
       "requires": {
         "@automattic/calypso-build": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "grunt": "~0.4.5",
     "grunt-wp-i18n": "~0.5.0",
     "grunt-wp-readme-to-markdown": "~1.0.0",
-    "newspack-scripts": "^5.3.0"
+    "newspack-scripts": "^5.5.1"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the `newspack-scripts` to 5.5.1, which [fixes an issue with generating alpha releases](https://github.com/Automattic/newspack-scripts/pull/212).

### How to test the changes in this Pull Request:

1. Confirm that `npm run release:archive` looks okay! 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
