### PR TITLE
feat: add parse.ly tracking

### DIFF
--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -127,14 +127,14 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			echo '</div>'; // .article-info
 
 			// the text area that is copyable
-			echo wp_kses_post(
-				sprintf(
-					'<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">%1$s %2$s %3$s</textarea>',
-					esc_html( $article_info ),
-					$content . "\n\n",
-					$content_footer
-				)
-			);
+			?>
+				<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">
+					<?php echo esc_html( $article_info ); ?>
+					<?php echo $content; ?>
+
+					<?php echo htmlspecialchars($content_footer, ENT_QUOTES, 'UTF-8'); ?>
+				</textarea>
+			<?php
 			if ( ! $is_amp ) {
 				?>
 			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content', this)"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -207,12 +207,34 @@ final class Republication_Tracker_Tool {
 	}
 
 	/**
+	 * Create Parse.ly tracking code.
+	 *
+	 * @param $post_id Id of the post to track.
+	 */
+	public static function create_parsely_tracking($post_id) {
+		$parsely_settings        = get_option( 'parsely', [] );
+		if (empty($parsely_settings) || !isset($parsely_settings['apikey'])) {
+			return '';
+		}
+		$site_id = $parsely_settings['apikey'];
+		$article_url = get_permalink( $post_id );
+		return sprintf(
+			// %1$s is the original article URL, %2$s is site ID.
+			'<script> PARSELY = { autotrack: false, onload: function() { PARSELY.beacon.trackPageView({ url: "%1$s", urlref: window.location.href }); } } </script> <script id="parsely-cfg" src="//cdn.parsely.com/keys/%2$s/p.js"></script>',
+			$article_url,
+			$site_id
+		);
+	}
+
+	/**
 	 * Get attribution text, which will be inserted at the end of the copyable content.
 	 *
 	 * @param $post The shared post.
 	 */
 	public static function create_content_footer( $post = null ) {
 		$pixel = self::create_tracking_pixel_markup( $post->ID );
+		$parsely_tracking = self::create_parsely_tracking( $post->ID );
+		$tracking_html = htmlentities( $pixel ) . htmlentities($parsely_tracking);
 
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 		if ( 'on' === $display_attribution && null !== $post ) {
@@ -232,10 +254,10 @@ final class Republication_Tracker_Tool {
 					get_permalink( $post ),
 					home_url(),
 					esc_html( get_bloginfo() )
-				) . htmlentities( $site_icon_markup ) . htmlentities( $pixel )
+				) . htmlentities( $site_icon_markup ) . $tracking_html
 			);
 		}
-		return htmlentities( $pixel );
+		return $tracking_html;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds parse.ly tracking code to the republished content if a `wp-parsely` plugin configuration is found.  

### How to test the changes in this Pull Request:

1. Configure `wp-parsely` plugin or just add the appropriate option*
2. Click the "Republish This Story" button** and observe the parse.ly tracking code is present in the text to be copied
3. Ensure the parse.ly tracking code is in the following format:

```
<script> PARSELY = { autotrack: false, onload: function() { PARSELY.beacon.trackPageView({ url: 'XXXXX', urlref: window.location.href }); } } </script> <script id="parsely-cfg" src="//cdn.parsely.com/keys/#####/p.js"></script>
```

where the `#####` would be replaced by the site ID and `XXXXX` would be set to the original URL of the article on the publisher's website. 

\* `wp option set parsely '{"apikey": "site-address.com"}' --format=json`
\** this can be added as a sidebar widget

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204364074266322