### PR TITLE
fix: get remote page title was too greedy

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -14,7 +14,7 @@ function wprtt_get_referring_page_title( $url, $post_id ) {
 	if ( ! is_wp_error( $response ) ) {
 
 		// find the title element inside of the response body.
-		$response = preg_match( '/<title.[^>]*>(.*)<\/title>/siU', $response['body'], $title_matches );
+		$response = preg_match( '/<title.[^>]*>([^<]*)<\/title>/siU', $response['body'], $title_matches );
 
 		// if a title element was found, let's get the text from it.
 		if ( $title_matches ) {

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -140,12 +140,12 @@ if ( isset( $_GET['post'] ) ) {
 					'name'   => 'page_view',
 					// Params for page_view events: https://developers.google.com/analytics/devguides/collection/ga4/views?client_type=gtag.
 					'params' => [
-						'page_title'       => $url_title,
-						'page_location'    => $shared_post_permalink,
-						'page_referrer'    => $url,
-						'shared_post_id'   => $shared_post->ID,
-						'shared_post_slug' => $shared_post_slug,
-						'shared_post_url'  => $shared_post_permalink,
+						'page_title'       => substr( $url_title, 0, 100 ),
+						'page_location'    => substr( $shared_post_permalink, 0, 100 ),
+						'page_referrer'    => substr( $url, 0, 100 ),
+						'shared_post_id'   => substr( $shared_post->ID, 0, 100 ),
+						'shared_post_slug' => substr( $shared_post_slug, 0, 100 ),
+						'shared_post_url'  => substr( $shared_post_permalink, 0, 100 ),
 					],
 				],
 			],

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -5,10 +5,12 @@
  *
  * @param string $url URL of the referrer.
  * @param int    $post_id ID of the shared post.
- * @return string|void Title of the referring URL, or void if we can't find it.
+ * @return string Title of the referring URL, or empty string if we can't find it.
  */
 function wprtt_get_referring_page_title( $url ) {
 	$response = \wp_remote_get( $url );
+
+	$title = '';
 
 	// if there was no issue grabbing the url, grab the title.
 	if ( ! is_wp_error( $response ) ) {
@@ -25,9 +27,11 @@ function wprtt_get_referring_page_title( $url ) {
 			$title = rawurlencode( $title );
 
 			// return our found title.
-			return urldecode( $title );
+			$title = urldecode( $title );
 		}
 	}
+
+	return $title;
 }
 
 /**

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -7,14 +7,14 @@
  * @param int    $post_id ID of the shared post.
  * @return string|void Title of the referring URL, or void if we can't find it.
  */
-function wprtt_get_referring_page_title( $url, $post_id ) {
+function wprtt_get_referring_page_title( $url ) {
 	$response = \wp_remote_get( $url );
 
-	// if there was no issue grabbing the url, continue.
+	// if there was no issue grabbing the url, grab the title.
 	if ( ! is_wp_error( $response ) ) {
 
 		// find the title element inside of the response body.
-		$response = preg_match( '/<title.[^>]*>([^<]*)<\/title>/siU', $response['body'], $title_matches );
+		$response = preg_match( '/<title[^>]*>(.*)<\/title>/iU', $response['body'], $title_matches );
 
 		// if a title element was found, let's get the text from it.
 		if ( $title_matches ) {
@@ -26,12 +26,6 @@ function wprtt_get_referring_page_title( $url, $post_id ) {
 
 			// return our found title.
 			return urldecode( $title );
-
-		} else {
-
-			// if there were no title matches found, use the original post title.
-			return \get_the_title( $post_id );
-
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See 1200550061930446-as-1206802923753753

In some cases, for some reason I didn't completely understand, the method to fetch the page title was returning the whole page HTML, and thus breaking the GA4 event payload. Params values can have up to 100 chars.

This PR changes the regexp to be more specific (it fixed the issues in the posts I was seeing it), but also adds a safeguard in the ga4 params payload to make sure values are within the size limit.

### How to test the changes in this Pull Request:

1. Confirm things still work
2. Ask me about problematic posts (or check Asana task)
