### PR TITLE
Fix textarea font 

### DIFF
--- a/assets/widget.css
+++ b/assets/widget.css
@@ -71,10 +71,11 @@
   background-color: #fff;
   padding: 2em;
   text-align: left;
-  width: ;
 }
 
 #republication-tracker-tool-modal-content textarea {
+  font-family: monospace;
+  font-size: smaller;
   box-sizing: border-box;
   width: 100%;
   margin: 0.5em 0 2em 0;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -194,7 +194,7 @@ class Republication_Tracker_Tool_Settings {
 	}
 
 	public function republication_tracker_tool_license_callback() {
-		$selected = get_option( 'republication_tracker_tool_license' );
+		$selected = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
 
 		$licenses = REPUBLICATION_TRACKER_TOOL_LICENSES;
 
@@ -214,7 +214,7 @@ class Republication_Tracker_Tool_Settings {
 					/>
 					<?php esc_html_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
 				</label>
-				</br/>
+				<br>
 			<?php endforeach; ?>
 			</p>
 		</fieldset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This changes the textarea in the republication modal to use monospace. Some of the fonts used on sites would use ligatures for stuff like `/>` and just not look too good.

I also threw in an HTML fix and a default for a `get_option` to get rid of undefined index errors.

### How to test the changes in this Pull Request:

1. Enable the `republication-tracker-tool` and add the widget to the sidebar of posts.
2. When you click the "Republish this article" button, you should see the text in the textarea as monospace.
3. Delete any license settings you might have had: `wp option delete republication_tracker_tool_license` 
4. Now you go to `wp-admin/options-reading.php` The 'CC BY-NC 4.0' license should be chosen in the radios under 'License' 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209583710797962