### PR TITLE
fix(repub-tool): remove amp conditionals

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -52,11 +52,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 			return;
 		}
 
-		$is_amp = self::is_amp();
-
-		if ( ! $is_amp ) {
-			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
-		}
+		wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), filemtime( plugin_dir_path(__FILE__) ) );
 
 		echo wp_kses_post( $args['before_widget'] );
@@ -69,7 +65,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		if ( empty( $instance['layout'] ) || 'modal' === $instance['layout'] ) {
 			echo sprintf(
-				'<p><button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal"' : '' ) . ' name="%1$s" id="cc-btn" class="republication-tracker-tool-button modal">%1$s</button></p>',
+				'<p><button name="%1$s" id="cc-btn" class="republication-tracker-tool-button modal">%1$s</button></p>',
 				esc_html__( 'Republish This Story', 'republication-tracker-tool' )
 			);
 		}
@@ -107,19 +103,11 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 			// define our path to grab file content from
 			$modal_content_path = plugin_dir_path( __FILE__ ) . 'shareable-content.php';
 
-			if ( $is_amp ) {
-				?>
-					<amp-lightbox id="republication-tracker-tool-modal" layout="nodisplay" role="dialog" aria-modal="true" aria-labelledby="republish-modal-label">
-						<?php echo esc_html( include_once $modal_content_path ); ?>
-					</amp-lightbox>
-				<?php
-			} else {
-				?>
-					<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>" role="dialog" aria-modal="true" aria-labelledby="republish-modal-label">
-						<?php echo esc_html( include_once $modal_content_path ); ?>
-					</div>
-				<?php
-			}
+			?>
+				<div id="republication-tracker-tool-modal" style="display:none;" data-postid="<?php echo esc_attr( $post->ID ); ?>" data-pluginsdir="<?php echo esc_attr( plugins_url() ); ?>" role="dialog" aria-modal="true" aria-labelledby="republish-modal-label">
+					<?php echo esc_html( include_once $modal_content_path ); ?>
+				</div>
+			<?php
 		}
 	}
 
@@ -172,7 +160,4 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		return $instance;
 	}
 
-	public static function is_amp() {
-		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
-	}
 }

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -100,9 +100,9 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 $license_key = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
 
-echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
-	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
-	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
+echo '<div id="republication-tracker-tool-modal-content" style="display:none;">';
+	echo '<button class="republication-tracker-tool-close">';
+	echo '<span class="screen-reader-text">' . esc_html__( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
 	echo sprintf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons
@@ -136,11 +136,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 
 					<?php echo htmlspecialchars($content_footer, ENT_QUOTES, 'UTF-8'); ?>
 				</textarea>
-			<?php
-			if ( ! $is_amp ) {
-				?>
-			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content', this)"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
-				<?php
-			}
+				<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content', this)"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 
+			<?php
 			echo '</div>'; // #republication-tracker-tool-modal-content


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
 This is a quick cleanup PR that just removes the conditionals that we used when AMP was around.

### How to test the changes in this Pull Request:

1. Eyeball the code changes.
2. Add the widget to the sidebar on posts and check that the button and the modal behave the same as always.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?