### PR TITLE
feat(republication-tracker): Add additional tracking code snippet feature

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -47,12 +47,6 @@ class Republication_Tracker_Tool_Settings {
 
 		$settings = [
 			[
-				'key'               => 'republication_tracker_additional_tracking_code',
-				'label'             => esc_html__( 'Additional Tracking Code', 'republication-tracker-tool' ),
-				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
-				'sanitize_callback' => 'htmlentities',
-			],
-			[
 				'key'      => 'republication_tracker_tool_policy',
 				'label'    => esc_html__( 'Policy', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_policy_callback' ),
@@ -81,6 +75,12 @@ class Republication_Tracker_Tool_Settings {
 				'key'      => 'republication_tracker_tool_license',
 				'label'    => esc_html__( 'License', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_license_callback' ),
+			],
+			[
+				'key'               => 'republication_tracker_additional_tracking_code',
+				'label'             => esc_html__( 'Additional Tracking Code', 'republication-tracker-tool' ),
+				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
+				'sanitize_callback' => 'htmlentities',
 			],
 		];
 		foreach ( $settings as $setting ) {

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -130,7 +130,7 @@ class Republication_Tracker_Tool_Settings {
 		$content = html_entity_decode( get_option( 'republication_tracker_additional_tracking_code' ) );
 		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'Use placeholders: <strong>{{post-id}}</strong> will be replaced with the post ID, and <strong>{{post-url}}</strong> will be replaced with the post URL.', 'republication-tracker-tool' ) ) );
 		echo sprintf(
-			'<textarea name="%1$s" rows="5" cols="50">%2$s</textarea>',
+			'<textarea name="%1$s" rows="5" cols="150">%2$s</textarea>',
 			'republication_tracker_additional_tracking_code',
 			esc_textarea( $content )
 		);

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -47,6 +47,12 @@ class Republication_Tracker_Tool_Settings {
 
 		$settings = [
 			[
+				'key'               => 'republication_tracker_additional_tracking_code',
+				'label'             => esc_html__( 'Additional Tracking Code', 'republication-tracker-tool' ),
+				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
+				'sanitize_callback' => 'htmlentities',
+			],
+			[
 				'key'      => 'republication_tracker_tool_policy',
 				'label'    => esc_html__( 'Policy', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_policy_callback' ),
@@ -88,7 +94,7 @@ class Republication_Tracker_Tool_Settings {
 			register_setting(
 				'reading',
 				$setting['key'],
-				'wp_kses_post'
+				$setting['sanitize_callback'] ?? 'wp_kses_post'
 			);
 		}
 	}
@@ -115,6 +121,20 @@ class Republication_Tracker_Tool_Settings {
 			);
 		}
 
+	}
+
+	/**
+	 * Additional tracking code render callback.
+	 */
+	public function republication_tracker_additional_tracking_code_callback() {
+		$content = html_entity_decode( get_option( 'republication_tracker_additional_tracking_code' ) );
+		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'Use placeholders: <strong>{{post-id}}</strong> will be replaced with the post ID, and <strong>{{post-url}}</strong> will be replaced with the post URL.', 'republication-tracker-tool' ) ) );
+		echo sprintf(
+			'<textarea name="%1$s" rows="5" cols="50">%2$s</textarea>',
+			'republication_tracker_additional_tracking_code',
+			esc_textarea( $content )
+		);
+		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'The additional Tracking Code field is where you will be able to input your additional tracking code that will be appended to your copied content.', 'republication-tracker-tool' ) ) );
 	}
 
 	public function republication_tracker_tool_policy_callback() {

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -259,14 +259,28 @@ final class Republication_Tracker_Tool {
 	}
 
 	/**
+	 * Create additional tracking code HTML markup.
+	 *
+	 * @param $post_id Id of the post to track.
+	 * @return string additional tracking code HTML markup.
+	 */
+	public static function create_additional_tracking_code_markup( $post_id ) {
+		$additional_tracking_code = get_option( 'republication_tracker_additional_tracking_code' );
+		$additional_tracking_code = str_replace( '{{post-id}}', $post_id, $additional_tracking_code );
+		$additional_tracking_code = str_replace( '{{post-url}}', get_permalink( $post_id ), $additional_tracking_code );
+		return $additional_tracking_code;
+	}
+
+	/**
 	 * Get attribution text, which will be inserted at the end of the copyable content.
 	 *
 	 * @param $post The shared post.
 	 */
 	public static function create_content_footer( $post = null ) {
-		$pixel = self::create_tracking_pixel_markup( $post->ID );
-		$parsely_tracking = self::create_parsely_tracking( $post->ID );
-		$tracking_html = htmlentities( $pixel ) . htmlentities($parsely_tracking);
+		$pixel                    = self::create_tracking_pixel_markup( $post->ID );
+		$parsely_tracking         = self::create_parsely_tracking( $post->ID );
+		$additional_tracking_code = self::create_additional_tracking_code_markup( $post->ID );
+		$tracking_html            = htmlentities( $pixel ) . htmlentities($parsely_tracking) . $additional_tracking_code;
 
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 		if ( 'on' === $display_attribution && null !== $post ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses https://app.asana.com/1/26890605006346/task/1208711018003757?focus=true.

New Option for Custom Tracking Code:
- This PR adds a new option in the Republication Tracker admin settings allowing publishers to input an additional tracking code snippet (e.g. pixel, JavaScript, etc.). The option is rendered as a text area with clear help text indicating that two wildcards are supported:
    - {{post-id}}: Will be dynamically replaced with the current post's ID.
    - {{post-url}}: Will be dynamically replaced with the current post's URL.

Integration with RTT Output:
- The custom tracking code is appended at the end of the republished content output (the RTT output), ensuring that when users copy and paste the republished post, and the tracking code is automatically included.

Publishers can now tailor the tracking snippet to include any additional pixels or JavaScript needed, without modifying the core tool code.

Demo:-
| Admin Settings | Tracking Snippet |
|--------|--------|
| <img width="1576" alt="Screenshot 2025-03-11 at 5 55 28 PM" src="https://github.com/user-attachments/assets/1d4bdfbb-39fe-4714-8166-642dd8321f87" /> | <img width="863" alt="Screenshot 2025-03-11 at 5 56 04 PM" src="https://github.com/user-attachments/assets/b08f8309-f87b-4ac2-9b2d-90b510713cd9" /> | 

### How to test the changes in this Pull Request:

1. Navigate to the Reading Settings> Republication Tracker settings in your WordPress admin.
2. Add tracking script or pixel(img tag). Ensure you include the dynamic wildcards ({{post-id}} and {{post-url}}). Example :
 `<script async src="https://example.com/tracker.js" data-id="{{post-id}}" data-url="{{post-url}}"></script>`.
3. Add dynamic wildcards for post_id & post_url.
4. Save and open any republishable post on the frontend and click the republish button.
5. Confirm that the output (the content to be copied for republishing) has the custom tracking snippet appended at the end, with the wildcards replaced appropriately.
6. Copy the republish snippet and paste it into another site to verify that the tracking code works as expected.
