### PR TITLE
Hotfix/media distribution

### DIFF
--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Republication Tracker Tool Content.
+ *
+ * @since   1.0
+ * @package Republication_Tracker_Tool
+ */
+
+/**
+ * Republication Tracker Tool Content class.
+ *
+ * @since 1.0
+ */
+class Republication_Tracker_Tool_Content {
+	/**
+	 * Filter the content for the republication.
+	 *
+	 * @param string $content The post content.
+	 * @param int    $post_id The post ID – should be supplied if different than the current post ID.
+	 */
+	public static function get_republishable_content( $content, $post_id = false ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+
+		// Remove shortcodes from the content.
+		$content = strip_shortcodes( $content );
+
+		// Remove comments from the content. (Lookin' at you, Gutenberg.)
+		$content = preg_replace( '/<!--(.|\s)*?-->/i', ' ', $content );
+
+		// And finally, remove some tags.
+		$content = wp_kses( $content, $allowed_tags_excerpt );
+
+		// remove spare p tags and clean up these paragraphs
+		$content = str_replace( '<p></p>', '', wpautop( $content ) );
+
+		// Force the content to be UTF-8 escaped HTML.
+		$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
+
+		// Handle media.
+		preg_match_all( '/<img[^>]+class="wp-image-(\d+)"[^>]*>/', $content, $matches );
+		$found_images = [];
+
+		foreach ( $matches[1] as $key => $attachment_id ) {
+			if ( ! Republication_Tracker_Tool_Media::can_distribute( $attachment_id ) ) {
+				$found_images[ $attachment_id ] = $matches[0][ $key ];
+			}
+		}
+
+		// Suppress the found images conditionally.
+		foreach ( $found_images as $attachment_id => $found_image ) {
+			// Remove the figure and figcaption of $found_image using regex.
+			$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
+			$content = preg_replace( $pattern, '', $content );
+		}
+
+		$post_object = get_post( $post_id );
+
+		/**
+		 * Filters the content of the republished post.
+		 *
+		 * @param string $content The content of the post.
+		 * @param string $post_object The post object.
+		 * @return string The filtered content.
+		 */
+		$content = apply_filters( 'republication_tracker_tool_republish_content', $content, $post_object );
+
+		return $content;
+	}
+}

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -29,6 +29,33 @@ class Republication_Tracker_Tool_Content {
 		// Remove comments from the content. (Lookin' at you, Gutenberg.)
 		$content = preg_replace( '/<!--(.|\s)*?-->/i', ' ', $content );
 
+		/**
+		 * What tags do we want to keep in the embed?
+		 * Not things from our server.
+		 *
+		 * Generall: wp_kses_post, but not allowing the terms listed below because
+		 * - they're referencing assets on our server: audio, figure, img, track, video
+		 * - they're referencing the referenced asset: figure, figcaption
+		 * - they're not likely to work: form, button
+		 *
+		 * @var array $allowed_tags_excerpt
+		 * @link https://codex.wordpress.org/Function_Reference/wp_kses
+		 */
+		global $allowedposttags;
+		$allowed_tags_excerpt = $allowedposttags;
+		unset( $allowed_tags_excerpt['form'] );
+
+		/**
+		 * Allow sites to configure which tags are allowed to be output in the republication content
+		 *
+		 * Default value is the standard global $allowedposttags, except form elements.
+		 *
+		 * @link https://github.com/Automattic/republication-tracker-tool/issues/49
+		 * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
+		 * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
+		 */
+		$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt, $post );
+
 		// And finally, remove some tags.
 		$content = wp_kses( $content, $allowed_tags_excerpt );
 

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -69,25 +69,25 @@ class Republication_Tracker_Tool_Content {
 		// remove spare p tags and clean up these paragraphs
 		$content = str_replace( '<p></p>', '', wpautop( $content ) );
 
-		// Force the content to be UTF-8 escaped HTML.
-		$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
-
 		// Handle media.
 		preg_match_all( '/<img[^>]+class="wp-image-(\d+)"[^>]*>/', $content, $matches );
 		$found_images = [];
 
 		foreach ( $matches[1] as $key => $attachment_id ) {
 			if ( ! Republication_Tracker_Tool_Media::can_distribute( $attachment_id ) ) {
-				$found_images[ $attachment_id ] = $matches[0][ $key ];
+				$found_images[] = [ $attachment_id, $matches[0][ $key ] ];
 			}
 		}
 
-		// Suppress the found images conditionally.
-		foreach ( $found_images as $attachment_id => $found_image ) {
+		// Remove the found images.
+		foreach ( $found_images as [ $attachment_id, $found_image ] ) {
 			// Remove the figure and figcaption of $found_image using regex.
 			$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
-			$content = preg_replace( $pattern, '', $content );
+			$content = preg_replace( $pattern, "<!-- RTT removed image ({$attachment_id}) -->", $content );
 		}
+
+		// Force the content to be UTF-8 escaped HTML.
+		$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
 
 		$post_object = get_post( $post_id );
 

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -61,7 +61,7 @@ class Republication_Tracker_Tool_Content {
 		 * Filters the content of the republished post.
 		 *
 		 * @param string $content The content of the post.
-		 * @param string $post_object The post object.
+		 * @param WP_Post $post_object The post object.
 		 * @return string The filtered content.
 		 */
 		$content = apply_filters( 'republication_tracker_tool_republish_content', $content, $post_object );

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -16,7 +16,7 @@ class Republication_Tracker_Tool_Content {
 	 * Filter the content for the republication.
 	 *
 	 * @param string $content The post content.
-	 * @param int    $post_id The post ID – should be supplied if different than the current post ID.
+	 * @param int    $post_id Optional. Current post ID by default.
 	 */
 	public static function get_republishable_content( $content, $post_id = false ) {
 		if ( ! $post_id ) {

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -46,6 +46,13 @@ class Republication_Tracker_Tool_Content {
 		unset( $allowed_tags_excerpt['form'] );
 
 		/**
+		 * The article WP_Post object
+		 *
+		 * @var WP_Post $post the post object
+		 */
+		global $post;
+
+		/**
 		 * Allow sites to configure which tags are allowed to be output in the republication content
 		 *
 		 * Default value is the standard global $allowedposttags, except form elements.

--- a/includes/class-media.php
+++ b/includes/class-media.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Republication Tracker Tool Media.
+ *
+ * @since   1.0
+ * @package Republication_Tracker_Tool
+ */
+
+/**
+ * Republication Tracker Tool Media class.
+ *
+ * @since 1.0
+ */
+class Republication_Tracker_Tool_Media {
+	/**
+	 * Should the media element be distributed?
+	 *
+	 * @param int $media_id ID of the media element.
+	 */
+	public static function can_distribute( $media_id ) {
+		$media_distribution = get_option( 'republication_tracker_tool_media_distribution', 'on' );
+		if ( $media_distribution === 'on' ) {
+			// All media should be distributed, regardless of the individual setting.
+			return true;
+		}
+		// Otherwise, check the individual setting.
+		if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+			return (bool) get_post_meta( $media_id, \Newspack\Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
+		}
+
+		return false;
+	}
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -188,7 +188,7 @@ class Republication_Tracker_Tool_Settings {
 					checked
 				<?php endif; ?>
 			/>
-			<p><em><?php echo esc_html__( 'If checked, all media will be included in republication. Otherwise, only media specifically marked as distributable will be included. A media element can be marked as distributable in the media library.', 'republication-tracker-tool' ); ?></em></p>
+			<p><em><?php echo esc_html__( 'When you check the box, all the media from the original article will be included in the republished article. If you don’t want this to happen, mark media elements with “Can distribute?” toggle in your media library and leave this box unchecked. This way, republished articles will only show the elements you’ve marked as distributable.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -114,7 +114,6 @@ class Republication_Tracker_Tool_Settings {
 			'
 			);
 		}
-
 	}
 
 	public function republication_tracker_tool_policy_callback() {
@@ -130,12 +129,12 @@ class Republication_Tracker_Tool_Settings {
 				'teeny'         => true,
 			)
 		);
-		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy hat uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.', 'republication-tracker-tool' ) ) );
+		printf( '<p><em>%s</em></p>', wp_kses_post( __( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy hat uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.', 'republication-tracker-tool' ) ) );
 	}
 
 	public function republication_tracker_tool_analytics_id_callback() {
 		$content = get_option( 'republication_tracker_tool_analytics_id' );
-		echo sprintf(
+		printf(
 			'<input type="text" name="%1$s" value="%2$s">%3$s',
 			'republication_tracker_tool_analytics_id',
 			esc_html( $content ),
@@ -145,7 +144,7 @@ class Republication_Tracker_Tool_Settings {
 
 	public function republication_tracker_tool_analytics_ga4_id_callback() {
 		$content = get_option( 'republication_tracker_tool_analytics_ga4_id' );
-		echo sprintf(
+		printf(
 			'<input type="text" name="%1$s" value="%2$s">%3$s',
 			'republication_tracker_tool_analytics_ga4_id',
 			esc_html( $content ),
@@ -155,7 +154,7 @@ class Republication_Tracker_Tool_Settings {
 
 	public function republication_tracker_tool_analytics_ga4_secret_callback() {
 		$content = get_option( 'republication_tracker_tool_analytics_ga4_secret' );
-		echo sprintf(
+		printf(
 			'<input type="text" name="%1$s" value="%2$s">%3$s',
 			'republication_tracker_tool_analytics_ga4_secret',
 			esc_html( $content ),
@@ -189,7 +188,7 @@ class Republication_Tracker_Tool_Settings {
 					checked
 				<?php endif; ?>
 			/>
-			<p><em><?php echo esc_html__( 'If checked, all media will be included in republication. Unchecked only media specifically tagged as distributable will be included..', 'republication-tracker-tool' ); ?></em></p>
+			<p><em><?php echo esc_html__( 'If checked, all media will be included in republication. Otherwise, only media specifically marked as distributable will be included. A media element can be marked as distributable in the media library.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
 	}
 
@@ -201,7 +200,7 @@ class Republication_Tracker_Tool_Settings {
 		?>
 		<fieldset>
 			<p>
-			<?php foreach( $licenses as $license_key => $license_values ) : ?>
+			<?php foreach ( $licenses as $license_key => $license_values ) : ?>
 				<label>
 					<input
 						type="radio"

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -74,7 +74,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 			);
 		}
 
-		if ( 'page' === $instance['layout'] ) {
+		if ( ! empty($instance['layout']) && 'page' === $instance['layout'] ) {
 			echo sprintf(
 				'<p><button name="%1$s" id="cc-btn" class="republication-tracker-tool-button page" onclick="window.location.href=\'%2$s\'" role="link">%1$s</button></p>',
 				esc_html__( 'Republish This Story', 'republication-tracker-tool' ),

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -16,33 +16,6 @@
 global $post;
 
 /**
- * What tags do we want to keep in the embed?
- * Not things from our server.
- *
- * Generall: wp_kses_post, but not allowing the terms listed below because
- * - they're referencing assets on our server: audio, figure, img, track, video
- * - they're referencing the referenced asset: figure, figcaption
- * - they're not likely to work: form, button
- *
- * @var array $allowed_tags_excerpt
- * @link https://codex.wordpress.org/Function_Reference/wp_kses
- */
-global $allowedposttags;
-$allowed_tags_excerpt = $allowedposttags;
-unset( $allowed_tags_excerpt['form'] );
-
-/**
- * Allow sites to configure which tags are allowed to be output in the republication content
- *
- * Default value is the standard global $allowedposttags, except form elements.
- *
- * @link https://github.com/Automattic/republication-tracker-tool/issues/49
- * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
- * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
- */
-$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt, $post );
-
-/**
  * The content of the aforementioned post
  *
  * @var HTML $content

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -47,22 +47,7 @@ $allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_
  *
  * @var HTML $content
  */
-$content = $post->post_content;
-
-// Remove shortcodes from the content.
-$content = strip_shortcodes( $content );
-
-// Remove comments from the content. (Lookin' at you, Gutenberg.)
-$content = preg_replace( '/<!--(.|\s)*?-->/i', ' ', $content );
-
-// And finally, remove some tags.
-$content = wp_kses( $content, $allowed_tags_excerpt );
-
-// remove spare p tags and clean up these paragraphs
-$content = str_replace( '<p></p>', '', wpautop( $content ) );
-
-// Force the content to be UTF-8 escaped HTML.
-$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
+$content = Republication_Tracker_Tool_Content::get_republishable_content( $post->post_content );
 
 $content_footer = Republication_Tracker_Tool::create_content_footer( $post );
 
@@ -103,12 +88,12 @@ $license_key = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
 	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
-	echo sprintf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
+	printf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
-			echo sprintf( '<a rel="noreferrer license" target="_blank" href="%s" /></a>', REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge'], esc_html__( 'Creative Commons License', 'republication-tracker-tool' ) );
+			printf( '<a rel="noreferrer license" target="_blank" href="%s" /></a>', REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge'], esc_html__( 'Creative Commons License', 'republication-tracker-tool' ) );
 			echo wp_kses_post(
 				wpautop(
 					sprintf(
@@ -134,7 +119,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 					<?php echo esc_html( $article_info ); ?>
 					<?php echo $content; ?>
 
-					<?php echo htmlspecialchars($content_footer, ENT_QUOTES, 'UTF-8'); ?>
+					<?php echo htmlspecialchars( $content_footer, ENT_QUOTES, 'UTF-8' ); ?>
 				</textarea>
 			<?php
 			if ( ! $is_amp ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,15 @@
 
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+		<exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement.PostIncrementFound" />
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames" />
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found" />
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 	</rule>
 
 	<rule ref="PHPCompatibilityWP"/>
@@ -25,4 +34,5 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/assets/dist/*</exclude-pattern>
+	<exclude-pattern>*/release/*</exclude-pattern>
 </ruleset>

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -27,6 +27,7 @@ define( 'REPUBLICATION_TRACKER_TOOL_PATH', plugin_dir_path( __FILE__ ) );
 require plugin_dir_path( __FILE__ ) . 'includes/licenses.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-media.php';
+require plugin_dir_path( __FILE__ ) . 'includes/class-content.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-widget.php';
 require plugin_dir_path( __FILE__ ) . 'includes/compatibility-co-authors-plus.php';

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -26,6 +26,7 @@ define( 'REPUBLICATION_TRACKER_TOOL_PATH', plugin_dir_path( __FILE__ ) );
 
 require plugin_dir_path( __FILE__ ) . 'includes/licenses.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-settings.php';
+require plugin_dir_path( __FILE__ ) . 'includes/class-media.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-widget.php';
 require plugin_dir_path( __FILE__ ) . 'includes/compatibility-co-authors-plus.php';

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -7,8 +7,6 @@
  * @package Republication_Tracker_Tool
  */
 
-use Newspack\Newspack_Image_Credits;
-
 get_header();
 
 global $allowedposttags;
@@ -60,9 +58,7 @@ if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
 	$found_images = array();
 
 	foreach ( $matches[1] as $key => $attachment_id ) {
-		$can_distribute = get_post_meta( $attachment_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
-
-		if ( empty( $can_distribute ) ) {
+		if ( ! Republication_Tracker_Tool_Media::can_distribute( $attachment_id ) ) {
 			$found_images[ $attachment_id ] = $matches[0][ $key ];
 		}
 	}
@@ -107,16 +103,10 @@ $article_date->setTimezone( $current_timezone );
 $article_date = $article_date->format( 'M j g:ia T' );
 
 // Featured image.
-$featured_image = get_the_post_thumbnail( $republish_post_id, 'full' );
-
-if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
-	$featured_media_id             = get_post_thumbnail_id( $republish_post_id );
-	$can_distribute_featured_image = get_post_meta( $featured_media_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
-	$media_distribution            = get_option( 'republication_tracker_tool_media_distribution', 'on' );
-
-	if ( empty( $media_distribution ) && empty( $can_distribute_featured_image ) ) {
-		$featured_image = '';
-	}
+if ( Republication_Tracker_Tool_Media::can_distribute( get_post_thumbnail_id( $republish_post_id ) ) ) {
+	$featured_image = get_the_post_thumbnail( $republish_post_id, 'full' );
+} else {
+	$featured_image = '';
 }
 
 // Canonical URL.

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -36,43 +36,7 @@ if ( ! $post_object instanceof WP_Post ) {
 	wp_die( esc_html__( 'Invalid post ID.', 'republication-tracker-tool' ) );
 }
 
-$content = $post_object->post_content;
-
-// Remove shortcodes.
-$content = strip_shortcodes( $content );
-
-// Remove comments from content.
-$content = preg_replace( '/<!--(.|\s)*?-->/i', '', $content );
-
-// Remove some tags.
-$content = wp_kses( $content, $allowed_tags_excerpt );
-
-// Remove empty paragraphs.
-$content = str_replace( '<p></p>', '', wpautop( $content ) );
-
-// Remove the image if "can distribute" is not set.
-if ( class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
-
-	// Find all the attachments id in the content.
-	preg_match_all( '/<img[^>]+class="wp-image-(\d+)"[^>]*>/', $content, $matches );
-	$found_images = array();
-
-	foreach ( $matches[1] as $key => $attachment_id ) {
-		if ( ! Republication_Tracker_Tool_Media::can_distribute( $attachment_id ) ) {
-			$found_images[ $attachment_id ] = $matches[0][ $key ];
-		}
-	}
-
-	// Suppress the found images if "can distribute" is not set.
-	foreach ( $found_images as $attachment_id => $found_image ) {
-		// Remove the figure and figcaption of $found_image using regex.
-		$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
-		$content = preg_replace( $pattern, '', $content );
-	}
-}
-
-// Apply filters to the content.
-$content = apply_filters( 'republication_tracker_tool_republish_content', $content, $post_object );
+$content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
 // Get the license statement.
 $license_statement = get_option( 'republication_tracker_tool_policy' );

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -9,22 +9,6 @@
 
 get_header();
 
-global $allowedposttags;
-$allowed_tags_excerpt = $allowedposttags;
-unset( $allowed_tags_excerpt['form'] );
-
-/**
- * Allow sites to configure which tags are allowed to be output in the republication content
- *
- * Default value is the standard global $allowedposttags, except form elements.
- *
- * @link https://github.com/Automattic/republication-tracker-tool/issues/49
- * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
- *
- * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
- */
-$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt, $post );
-
 // Get post ID from query var.
 $republish_post_id = get_query_var( 'republish_post_id' );
 


### PR DESCRIPTION
Fixes a few issues:

1. Empty item read, which just cause a PHP warning to be logged
2. Updates PHPCS config, so automated PHPCS checks could be added in the future
3. Fixes an issue with #233 – the media distribution settings were only honored in the new `/republish/` template, but not in the republishing modal – this PR fixes it and aligns the content rendered in both places 