### PR TITLE
Fix license details on repub-page

### DIFF
--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -17,6 +17,9 @@
 }
 
 .republish-article__info textarea {
+	font-family: monospace;
+	font-size: smaller;
+	text-align: left;
 	border: 2px solid #c7c7c7;
 	height: 50vh;
 	line-height: 1.6em;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -213,7 +213,7 @@ class Republication_Tracker_Tool_Settings {
 	}
 
 	public function republication_tracker_tool_license_callback() {
-		$selected = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
+		$selected = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 
 		$licenses = REPUBLICATION_TRACKER_TOOL_LICENSES;
 

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -41,7 +41,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		global $post;
 
-		$license_key = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
+		$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 
 		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
 		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ), $post );

--- a/includes/licenses.php
+++ b/includes/licenses.php
@@ -1,4 +1,6 @@
 <?php
+
+const REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE = 'cc-by-nd-4.0';
 const REPUBLICATION_TRACKER_TOOL_LICENSES = [
 	'cc-by-4.0' => [
 		'label' => 'CC BY 4.0',
@@ -24,7 +26,7 @@ const REPUBLICATION_TRACKER_TOOL_LICENSES = [
 		'url' => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
 		'badge' => 'https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png'
 	],
-	'cc-by-nd-4.0' => [
+	REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE => [
 		'label' => 'CC BY-ND 4.0',
 		'description' => 'Creative Commons Attribution-NoDerivatives 4.0 International License',
 		'url' => 'https://creativecommons.org/licenses/by-nd/4.0/',

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -56,7 +56,7 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  * @var HTML $license_statement
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
-$license_key = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
+$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -41,6 +41,11 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-republication-rewrite.php'
 final class Republication_Tracker_Tool {
 
 	/**
+	 * The default license key to use if none is chosen in the backend UI.
+	 */
+	const DEFAULT_LICENSE = 'cc-by-nd-4.0';
+
+	/**
 	 * URL of plugin directory.
 	 *
 	 * @var    string

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -41,11 +41,6 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-republication-rewrite.php'
 final class Republication_Tracker_Tool {
 
 	/**
-	 * The default license key to use if none is chosen in the backend UI.
-	 */
-	const DEFAULT_LICENSE = 'cc-by-nd-4.0';
-
-	/**
 	 * URL of plugin directory.
 	 *
 	 * @var    string

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -22,6 +22,7 @@ if ( ! $post_object instanceof WP_Post ) {
 
 $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
+$license_statement = get_option( 'republication_tracker_tool_policy' );
 $license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 $license_badge = sprintf(
 	'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
@@ -177,6 +178,11 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 						?>
 					</div>
 				</div>
+				<?php if ( ! empty( $license_statement ) ) : ?>
+					<section class="republish-article__license">
+						<?php echo wp_kses_post( $license_statement ); ?>
+					</section>
+				<?php endif; ?>
 				<div class="republish-article__content">
 					<section class="republish-article__info">
 						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>"><?php echo esc_html( $republish_content ); ?></textarea>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -22,8 +22,13 @@ if ( ! $post_object instanceof WP_Post ) {
 
 $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
-// Get the license statement.
-$license_statement = get_option( 'republication_tracker_tool_policy' );
+$license_key = get_option( 'republication_tracker_tool_license', Republication_Tracker_Tool::DEFAULT_LICENSE );
+$license_badge = sprintf(
+	'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
+	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge']
+);
 
 // Article title.
 $article_title = get_the_title( $republish_post_id );
@@ -155,12 +160,24 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 
 				<?php do_action( 'republication_tracker_tool_before_republish_content', $post_object ); ?>
 
+				<div class="cc-policy">
+					<div class="cc-license">
+						<?php
+						echo $license_badge;
+						echo wp_kses_post(
+							wpautop(
+								sprintf(
+								// translators: %1$s is the URL to the particular Creative Commons license.
+									__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
+									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+								)
+							)
+						);
+						?>
+					</div>
+				</div>
 				<div class="republish-article__content">
-					<?php if ( ! empty( $license_statement ) ) : ?>
-						<section class="republish-article__license">
-							<?php echo wp_kses_post( $license_statement ); ?>
-						</section>
-					<?php endif; ?>
 					<section class="republish-article__info">
 						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>"><?php echo esc_html( $republish_content ); ?></textarea>
 						<button class="republish-article__copy-button" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -22,7 +22,7 @@ if ( ! $post_object instanceof WP_Post ) {
 
 $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
-$license_key = get_option( 'republication_tracker_tool_license', Republication_Tracker_Tool::DEFAULT_LICENSE );
+$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 $license_badge = sprintf(
 	'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
 	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

 #248 Fixes the modal republication. This adds the fixes from #248 to the republication page as well.
It also adds some styling to the textarea that the modal has and fixes some mess if a policy was filled in in the settings.
 
 I added a constant for the default license because we used it in so many places.

It would be great to consolidate the output for those two, but that is going to be some other time.

### How to test the changes in this Pull Request:

1. Add the republication widget and choose 'page' in the radio button in the widget prefs.
2. Click the republication button on a post and verify that the output on the page has:
	1. The license icon
	2. The license text
	3. Monospace text in the textarea.

### Screenshots
#### Before
![CleanShot 2025-03-25 at 13 35 56@2x](https://github.com/user-attachments/assets/5eb6801b-310f-4e1f-b8d2-64405d1f9963)

#### After
![CleanShot 2025-03-25 at 13 34 27@2x](https://github.com/user-attachments/assets/b79f3682-8361-4708-b27d-d6d6e5586810)
