### PR TITLE
fix: only save post meta on intentional saves refs NPPM-342

### DIFF
--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -84,6 +84,14 @@ class Republication_Tracker_Tool_Article_Settings {
 	 */
 	public function save_hide_widget_metabox( $post_id ) {
 
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['republication-tracker-tool-hide-widget-submit'] ) ) {
+			return;
+		}
+
 		if ( isset( $_POST['republication-tracker-tool-hide-widget'] ) ) {
 
 			update_post_meta( $post_id, 'republication-tracker-tool-hide-widget', true );
@@ -164,6 +172,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		} else {
 
 			echo '<label>';
+				echo '<input type="hidden" name="republication-tracker-tool-hide-widget-submit" value="yes">';
 				echo '<input type="checkbox" name="republication-tracker-tool-hide-widget" id="republication-tracker-tool-hide-widget" ' . $checked . '>';
 				echo __( 'Hide the Republication sharing widget on this post?', 'republication-tracker-tool' );
 			echo '</label>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The "Hide widget" option is being cleared from posts when they shouldn't. 

We got a report that this was cleared when scheduled posts were published, but I also see this happening on auto saves.

### How to test the changes in this Pull Request:

Ensure you have the Republication Tracker Tool activated on your site.
Schedule a post for a couple minutes from now
Tick the box at the bottom of the settings column for the post to hide the tool
Schedule post and navigate away from post
Come back in a few minutes to see that the box is now unchecked, and that the widget is appearing.
