### PR TITLE
feat: default post & attachment distribution settings

### DIFF
--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -43,6 +43,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		add_action( 'manage_edit-post_sortable_columns', array( $this, 'add_sortable_columns' ) );
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_column_content' ), 10, 2 );
 		add_action( 'save_post', array( $this, 'save_hide_widget_metabox' ), 10 );
+		add_action( 'wp_insert_post', array( $this, 'apply_default_post_distribution' ), 10, 3 );
 	}
 
 
@@ -203,6 +204,24 @@ class Republication_Tracker_Tool_Article_Settings {
 				}
 				echo sprintf( '%s', number_format( $total_count ) );
 				break;
+		}
+	}
+
+	/**
+	 * Apply default post distribution settings to new posts.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 * @param bool    $update  Whether this is an existing post being updated.
+	 */
+	public function apply_default_post_distribution( $post_id, $post, $update ) {
+		// Only apply to new posts
+		if ( ! $update && 'post' === $post->post_type ) {
+			$default_post_distribution = get_option( 'republication_tracker_tool_default_post_distribution', 'off' );
+
+			if ( 'on' === $default_post_distribution ) {
+				update_post_meta( $post_id, 'republication-tracker-tool-hide-widget', true );
+			}
 		}
 	}
 

--- a/includes/class-media.php
+++ b/includes/class-media.php
@@ -13,6 +13,26 @@
  */
 class Republication_Tracker_Tool_Media {
 	/**
+	 * Initialize the class
+	 */
+	public static function init() {
+		add_action( 'add_attachment', array( __CLASS__, 'apply_default_attachment_distribution' ), 10, 1 );
+	}
+
+	/**
+	 * Apply default distribution setting to new attachments
+	 * 
+	 * @param int $attachment_id The attachment ID.
+	 */
+	public static function apply_default_attachment_distribution( $attachment_id ) {
+		$default_attachment_distribution = get_option( 'republication_tracker_tool_default_attachment_distribution', 'off' );
+
+		if ( 'on' === $default_attachment_distribution && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+			update_post_meta( $attachment_id, \Newspack\Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true );
+		}
+	}
+
+	/**
 	 * Should the media element be distributed?
 	 *
 	 * @param int $media_id ID of the media element.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -87,6 +87,11 @@ class Republication_Tracker_Tool_Settings {
 				'label'    => esc_html__( 'Default Post Distribution', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_default_post_distribution_callback' ),
 			],
+			[
+				'key'      => 'republication_tracker_tool_default_attachment_distribution',
+				'label'    => esc_html__( 'Default Attachment Distribution', 'republication-tracker-tool' ),
+				'callback' => array( $this, 'republication_tracker_tool_default_attachment_distribution_callback' ),
+			],
 		];
 		foreach ( $settings as $setting ) {
 			add_settings_field(
@@ -260,4 +265,18 @@ class Republication_Tracker_Tool_Settings {
 		<?php
 	}
 
+	public function republication_tracker_tool_default_attachment_distribution_callback() {
+		$default_attachment_distribution = get_option( 'republication_tracker_tool_default_attachment_distribution', 'off' );
+		?>
+			<input
+				type="checkbox"
+				id="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
+				name="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
+				<?php if ( 'on' === $default_attachment_distribution ) : ?>
+					checked
+				<?php endif; ?>
+			/>
+			<p><em><?php echo esc_html__( 'If checked, "Can distribute" will be enabled by default for new attachments.', 'republication-tracker-tool' ); ?></em></p>
+		<?php
+	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -82,6 +82,11 @@ class Republication_Tracker_Tool_Settings {
 				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
 				'sanitize_callback' => 'htmlentities',
 			],
+			[
+				'key'      => 'republication_tracker_tool_default_post_distribution',
+				'label'    => esc_html__( 'Default Post Distribution', 'republication-tracker-tool' ),
+				'callback' => array( $this, 'republication_tracker_tool_default_post_distribution_callback' ),
+			],
 		];
 		foreach ( $settings as $setting ) {
 			add_settings_field(
@@ -239,4 +244,20 @@ class Republication_Tracker_Tool_Settings {
 		</fieldset>
 		<?php
 	}
+
+	public function republication_tracker_tool_default_post_distribution_callback() {
+		$default_post_distribution = get_option( 'republication_tracker_tool_default_post_distribution', 'off' );
+		?>
+			<input
+				type="checkbox"
+				id="<?php echo esc_attr( 'republication_tracker_tool_default_post_distribution' ); ?>"
+				name="<?php echo esc_attr( 'republication_tracker_tool_default_post_distribution' ); ?>"
+				<?php if ( 'on' === $default_post_distribution ) : ?>
+					checked
+				<?php endif; ?>
+			/>
+			<p><em><?php echo esc_html__( 'If checked, "Hide Republication Widget" will be enabled by default for new posts.', 'republication-tracker-tool' ); ?></em></p>
+		<?php
+	}
+
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -72,6 +72,11 @@ class Republication_Tracker_Tool_Settings {
 				'callback' => array( $this, 'republication_tracker_tool_media_distribution_callback' ),
 			],
 			[
+				'key'      => 'republication_tracker_tool_default_attachment_distribution',
+				'label'    => '', // This is intentionally left blank to club it visually with Media Distribution.
+				'callback' => array( $this, 'republication_tracker_tool_default_attachment_distribution_callback' ),
+			],
+			[
 				'key'      => 'republication_tracker_tool_license',
 				'label'    => esc_html__( 'License', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_license_callback' ),
@@ -84,13 +89,8 @@ class Republication_Tracker_Tool_Settings {
 			],
 			[
 				'key'      => 'republication_tracker_tool_default_post_distribution',
-				'label'    => esc_html__( 'Enable default Post Distribution', 'republication-tracker-tool' ),
+				'label'    => esc_html__( 'Hide republication widgets on posts by default', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_default_post_distribution_callback' ),
-			],
-			[
-				'key'      => 'republication_tracker_tool_default_attachment_distribution',
-				'label'    => esc_html__( 'Enable default Attachment Distribution', 'republication-tracker-tool' ),
-				'callback' => array( $this, 'republication_tracker_tool_default_attachment_distribution_callback' ),
 			],
 		];
 		foreach ( $settings as $setting ) {
@@ -218,7 +218,28 @@ class Republication_Tracker_Tool_Settings {
 					checked
 				<?php endif; ?>
 			/>
+			<label for="<?php echo esc_attr( 'republication_tracker_tool_media_distribution' ); ?>">
+				<?php echo esc_html__( 'Distribute all media', 'republication-tracker-tool' ); ?>
+			</label>
 			<p><em><?php echo esc_html__( 'When you check the box, all the media from the original article will be included in the republished article. If you don’t want this to happen, mark media elements with “Can distribute?” toggle in your media library and leave this box unchecked. This way, republished articles will only show the elements you’ve marked as distributable.', 'republication-tracker-tool' ); ?></em></p>
+		<?php
+	}
+
+	public function republication_tracker_tool_default_attachment_distribution_callback() {
+		$default_attachment_distribution = get_option( 'republication_tracker_tool_default_attachment_distribution', 'off' );
+		?>
+			<input
+				type="checkbox"
+				id="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
+				name="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
+				<?php if ( 'on' === $default_attachment_distribution ) : ?>
+					checked
+				<?php endif; ?>
+			/>
+			<label for="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>">
+				<?php echo esc_html__( 'Mark media as distributable by default', 'republication-tracker-tool' ); ?>
+			</label>
+			<p><em><?php echo esc_html__( 'If checked, all new uploaded images will have their “Can distribute?” option enabled by default.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
 	}
 
@@ -262,21 +283,6 @@ class Republication_Tracker_Tool_Settings {
 				<?php endif; ?>
 			/>
 			<p><em><?php echo esc_html__( 'If checked, "Hide Republication Widget" will be enabled by default for new posts.', 'republication-tracker-tool' ); ?></em></p>
-		<?php
-	}
-
-	public function republication_tracker_tool_default_attachment_distribution_callback() {
-		$default_attachment_distribution = get_option( 'republication_tracker_tool_default_attachment_distribution', 'off' );
-		?>
-			<input
-				type="checkbox"
-				id="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
-				name="<?php echo esc_attr( 'republication_tracker_tool_default_attachment_distribution' ); ?>"
-				<?php if ( 'on' === $default_attachment_distribution ) : ?>
-					checked
-				<?php endif; ?>
-			/>
-			<p><em><?php echo esc_html__( 'If checked, "Can distribute" will be enabled by default for new attachments.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -84,12 +84,12 @@ class Republication_Tracker_Tool_Settings {
 			],
 			[
 				'key'      => 'republication_tracker_tool_default_post_distribution',
-				'label'    => esc_html__( 'Default Post Distribution', 'republication-tracker-tool' ),
+				'label'    => esc_html__( 'Enable default Post Distribution', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_default_post_distribution_callback' ),
 			],
 			[
 				'key'      => 'republication_tracker_tool_default_attachment_distribution',
-				'label'    => esc_html__( 'Default Attachment Distribution', 'republication-tracker-tool' ),
+				'label'    => esc_html__( 'Enable default Attachment Distribution', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_default_attachment_distribution_callback' ),
 			],
 		];

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -148,6 +148,8 @@ final class Republication_Tracker_Tool {
 		$this->article_settings = new Republication_Tracker_Tool_Article_Settings( $this );
 		$this->rewrite_endpoint = new Republication_Tracker_Tool_Rewrite_Endpoint();
 
+		Republication_Tracker_Tool_Media::init();
+
 		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
 
 		add_filter( 'plugin_row_meta', array( $this, '_plugin_row_meta' ), 10, 2 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210629622176521?focus=true.

#### New Global Defaults for Distribution Settings:
This PR introduces two new global options in the Republication Tracker plugin settings to allow publishers to define default behaviors for content distribution:

- Default Status for Post Distribution
- Default Status for Attachment Distribution

#### Behavior:
- These options determine the default value (enabled or disabled) for:
    - The "Can distribute" field on attachments (affects newly uploaded attachments only).
    - The "Hide republication widget" field on posts.

- These settings do not affect existing posts or attachments, but only control the initial state for newly created items.

This gives publishers control over default behavior without manually toggling the option for every post or media file.

### How to test the changes in this Pull Request:

1. Navigate to the WordPress admin → Settings → Reading.
2. You’ll find two new settings at the bottom:
    - Default Post Distribution.
    - Default Attachment Distribution.
3. Enable/disable these options and save.
4. Upload a new media attachment.
    - Verify that the “Can distribute” checkbox reflects the selected default.
5. Create a new post.
    - Verify that the “Hide republication widget” option reflects the default.
6. Confirm that:
    - Changing the default affects only newly created content.
    - Existing posts and attachments retain their saved settings.
