### PR TITLE
fix: lax filter for script

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -85,7 +85,7 @@ class Republication_Tracker_Tool_Settings {
 				'key'               => 'republication_tracker_additional_tracking_code',
 				'label'             => esc_html__( 'Additional Tracking Code', 'republication-tracker-tool' ),
 				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
-				'sanitize_callback' => 'wp_unslash',
+				'sanitize_callback' => array( $this, 'sanitize_tracking_code' ),
 			],
 			[
 				'key'      => 'republication_tracker_tool_default_post_distribution',
@@ -144,6 +144,7 @@ class Republication_Tracker_Tool_Settings {
 			esc_textarea( $content )
 		);
 		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'The additional Tracking Code field is where you will be able to input your additional tracking code that will be appended to your copied content.', 'republication-tracker-tool' ) ) );
+		echo sprintf( '<p><em>%s</em></p>', wp_kses_post( __( 'Allowed HTML: script, img, iframe, noscript, div, span, p with safe attributes only.', 'republication-tracker-tool' ) ) );
 	}
 
 	public function republication_tracker_tool_policy_callback() {
@@ -284,5 +285,46 @@ class Republication_Tracker_Tool_Settings {
 			/>
 			<p><em><?php echo esc_html__( 'If checked, "Hide Republication Widget" will be enabled by default for new posts.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
+	}
+
+	/**
+	 * Sanitize tracking code to allow only safe HTML elements for tracking.
+	 *
+	 * @param string $content The tracking code content to sanitize.
+	 * @return string Sanitized content.
+	 */
+	public function sanitize_tracking_code( $content ) {
+		$allowed_html = [
+			'script'   => [
+				'id'    => true,
+				'src'   => true,
+				'type'  => true,
+				'async' => true,
+				'defer' => true,
+				'class' => true,
+			],
+			'img'      => [
+				'id'     => true,
+				'style'  => true,
+				'src'    => true,
+				'alt'    => true,
+				'class'  => true,
+				'width'  => true,
+				'height' => true,
+			],
+			'iframe'   => [
+				'id'     => true,
+				'style'  => true,
+				'src'    => true,
+				'class'  => true,
+				'width'  => true,
+				'height' => true,
+			],
+			'noscript' => true,
+			'div'      => true,
+			'span'     => true,
+		];
+
+		return wp_kses( $content, $allowed_html );
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -85,7 +85,7 @@ class Republication_Tracker_Tool_Settings {
 				'key'               => 'republication_tracker_additional_tracking_code',
 				'label'             => esc_html__( 'Additional Tracking Code', 'republication-tracker-tool' ),
 				'callback'          => array( $this, 'republication_tracker_additional_tracking_code_callback' ),
-				'sanitize_callback' => 'htmlentities',
+				'sanitize_callback' => 'wp_unslash',
 			],
 			[
 				'key'      => 'republication_tracker_tool_default_post_distribution',

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -284,7 +284,7 @@ final class Republication_Tracker_Tool {
 		$pixel                    = self::create_tracking_pixel_markup( $post->ID );
 		$parsely_tracking         = self::create_parsely_tracking( $post->ID );
 		$additional_tracking_code = self::create_additional_tracking_code_markup( $post->ID );
-		$tracking_html            = htmlentities( $pixel ) . htmlentities( $parsely_tracking ) . $additional_tracking_code;
+		$tracking_html            = htmlentities( $pixel ) . htmlentities( $parsely_tracking ) . htmlentities( $additional_tracking_code );
 
 		$license_key         = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
 		$license_url         = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change will allow for rendering script, img, and iframe tags in the custom tracking snippet.

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210847760541320?focus=true .

### How to test the changes in this Pull Request:

1. Add `script` tag in to custom tracking snippet in Settings > Reading.
2. Save and check the tracking snipped being saved.
3. View any republisable post > Click `republish this story` button
4. Check the tracking snippet has script present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->