### PR TITLE
feat: Add plain text option

### DIFF
--- a/assets/clipboard-utils.js
+++ b/assets/clipboard-utils.js
@@ -1,0 +1,86 @@
+/**
+ * Clipboard utility for copying text to clipboard
+ *
+ * uses Clipboard API.
+ */
+window.ClipboardUtils = {
+	/**
+	 * Copy text to clipboard
+	 * @param {string} text - Text to copy
+	 * @returns {Promise<boolean>} - Promise resolving to success status
+	 */
+	async copyText(text) {
+		if (!navigator.clipboard) {
+			console.warn('Clipboard API not available');
+			return false;
+		}
+
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch (err) {
+			console.error('Failed to copy text:', err);
+			return false;
+		}
+	},
+
+	/**
+	 * Get text content from an element
+	 * @param {string|Element} elementOrSelector - Element or selector
+	 * @returns {string} - Text content
+	 */
+	getElementText(elementOrSelector) {
+		let element;
+		
+		if (typeof elementOrSelector === 'string') {
+			element = document.querySelector(elementOrSelector);
+		} else {
+			element = elementOrSelector;
+		}
+
+		if (!element) {
+			return '';
+		}
+
+		const tagName = element.tagName.toLowerCase();
+		if (tagName === 'input' || tagName === 'textarea') {
+			return element.value || '';
+		} else {
+			return element.textContent || element.innerText || '';
+		}
+	},
+
+	/**
+	 * Copy content from an element
+	 * @param {string|Element} elementOrSelector - Source element
+	 * @param {Element} button - Button element for feedback
+	 * @returns {Promise<boolean>} - Promise resolving to success status
+	 */
+	async copyFromElement(elementOrSelector, button) {
+		const text = this.getElementText(elementOrSelector);
+		if (!text) {
+			return false;
+		}
+
+		const success = await this.copyText(text);
+		
+		if (success && button) {
+			this.showButtonFeedback(button);
+		}
+
+		return success;
+	},
+
+	/**
+	 * Show temporary "Copied!" feedback on button
+	 * @param {Element} button - Button element
+	 */
+	showButtonFeedback(button) {
+		const originalText = button.textContent || button.innerText;
+		
+		button.textContent = 'Copied!';
+		setTimeout(() => {
+			button.textContent = originalText;
+		}, 2000);
+	}
+};

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -128,7 +128,7 @@
 	padding: 0.5rem 1rem;
 	border-radius: 0.25em;
 	cursor: pointer;
-	font-size: 14px;
+	font-size: 16px;
 	text-shadow: 1px 1px 1px #255b98;
 
 	&:hover {

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -35,3 +35,44 @@
 .republish-article__copy-button {
 	margin-top: 20px;
 }
+
+.republish-format-tabs {
+	display: flex;
+	border: 0;
+	margin-bottom: 1rem;
+}
+
+.republish-tab-button {
+	background: none;
+	border: none;
+	padding: 0.75rem 1.5rem;
+	cursor: pointer;
+	font-weight: 600;
+	color: #666;
+
+	&:hover {
+		color: #333;
+		background-color: #f5f5f5;
+	}
+
+	&.active {
+		color: #333;
+		border: 1px solid #333;
+	}
+}
+
+.republish-tab-content {
+	display: none;
+
+	&.active {
+		display: block;
+	}
+}
+
+.republish-content-container {
+	position: relative;
+}
+
+.republish-content-textarea {
+	width: 100%;
+}

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -38,27 +38,35 @@
 
 .republish-format-tabs {
 	display: flex;
-	border: 0;
-	margin-bottom: 1rem;
+	margin-bottom: 1.5rem;
+	border-bottom: 1px solid #e0e0e0;
 }
 
 .republish-format-tabs__button {
 	background: none;
 	border: none;
-	padding: 0.75rem 1.5rem;
+	padding: 1rem 1.5rem;
 	cursor: pointer;
-	font-weight: 600;
+	font-weight: 500;
 	color: #666;
+	position: relative;
+	transition: color 0.2s ease;
+	border-bottom: 2px solid transparent;
+	border-radius: 0;
 
 	&:hover {
-		color: #333;
-		background-color: #f5f5f5;
+		color: #e0e0e0;
+	}
+
+	&:focus {
+		outline: none;
+		color: #e0e0e0;
 	}
 }
 
 .republish-format-tabs__button--active {
 	color: #333;
-	border: 1px solid #333;
+	border-bottom: 3px solid #333;
 }
 
 .republish-content {

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -20,16 +20,15 @@
 	font-family: monospace;
 	font-size: smaller;
 	text-align: left;
-	border: 2px solid #c7c7c7;
-	height: 50vh;
+	border: 1px solid #ccc;
+	height: 40vh;
 	line-height: 1.6em;
 	overflow: scroll;
 	padding: 16px;
 }
 
 .republish-article__info textarea:focus {
-	border-color: #a7a7a7;
-	box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.2);
+	border-color: #1e1e1e;
 }
 
 .republish-article__copy-button {
@@ -45,28 +44,29 @@
 .republish-format-tabs__button {
 	background: none;
 	border: none;
-	padding: 1rem 1.5rem;
+	padding: 0.75rem 1.5rem;
 	cursor: pointer;
-	font-weight: 500;
-	color: #666;
+	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+	font-weight: 600;
+	color: #6c6c6c;
 	position: relative;
 	transition: color 0.2s ease;
-	border-bottom: 2px solid transparent;
+	border-bottom: 3px solid transparent;
 	border-radius: 0;
+	margin-bottom: -1px;
 
 	&:hover {
-		color: #e0e0e0;
+		color: #1e1e1e;
 	}
 
 	&:focus {
-		outline: none;
-		color: #e0e0e0;
+		color: #1e1e1e;
 	}
 }
 
 .republish-format-tabs__button--active {
-	color: #333;
-	border-bottom: 3px solid #333;
+	color: #1e1e1e;
+	border-bottom-color: currentcolor;
 }
 
 .republish-content {
@@ -94,7 +94,7 @@
 	display: block;
 	margin-bottom: 0.5rem;
 	font-weight: 600;
-	color: #333;
+	color: #1e1e1e;
 }
 
 .plain-text-field__input {
@@ -104,33 +104,28 @@
 	border-radius: 4px;
 	font-family: monospace;
 	font-size: 14px;
-	background-color: #f9f9f9;
+	background-color: white;
 	margin-bottom: 0.5rem;
 
 	&:focus {
 		outline: none;
-		border-color: #007cba;
-		box-shadow: 0 0 0 1px #007cba;
+		border-color: #1e1e1e;
 	}
 }
 
 .plain-text-field__button {
-	background: #007cba;
-	border: none;
+	background: #2a7ac2;
+	border: 1px solid #255b98;
 	color: white;
 	padding: 0.5rem 1rem;
-	border-radius: 4px;
+	border-radius: 0.25em;
 	cursor: pointer;
-	font-size: 14px;
-	transition: background-color 0.2s;
+	font-size: 1em;
+	text-shadow: 1px 1px 1px #255b98;
 
 	&:hover {
-		background: #005a87;
-	}
-
-	&:focus {
-		outline: 2px solid #007cba;
-		outline-offset: 2px;
+		background: #2863a7;
+		text-decoration: none;
 	}
 }
 

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -83,9 +83,14 @@
 	position: relative;
 }
 
+.republish-content__input,
 .republish-content__textarea {
-	margin: 1.5em 0;
+	margin: 1em 0 1em 0;
 	width: 100%;
+}
+
+.republish-content__input {
+	display: block;
 }
 
 .plain-text-field {

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -54,13 +54,15 @@
 	border-bottom: 3px solid transparent;
 	border-radius: 0;
 	margin-bottom: -1px;
+	font-size: 20px;
 
 	&:hover {
-		color: #1e1e1e;
+		color: #e0e0e0;
 	}
 
 	&:focus {
-		color: #1e1e1e;
+		outline: none;
+		color: #e0e0e0;
 	}
 }
 
@@ -95,6 +97,7 @@
 	margin-bottom: 0.5rem;
 	font-weight: 600;
 	color: #1e1e1e;
+	font-size: 16px;
 }
 
 .plain-text-field__input {
@@ -120,7 +123,7 @@
 	padding: 0.5rem 1rem;
 	border-radius: 0.25em;
 	cursor: pointer;
-	font-size: 1em;
+	font-size: 14px;
 	text-shadow: 1px 1px 1px #255b98;
 
 	&:hover {

--- a/assets/republish-template.css
+++ b/assets/republish-template.css
@@ -42,7 +42,7 @@
 	margin-bottom: 1rem;
 }
 
-.republish-tab-button {
+.republish-format-tabs__button {
 	background: none;
 	border: none;
 	padding: 0.75rem 1.5rem;
@@ -54,25 +54,82 @@
 		color: #333;
 		background-color: #f5f5f5;
 	}
-
-	&.active {
-		color: #333;
-		border: 1px solid #333;
-	}
 }
 
-.republish-tab-content {
-	display: none;
+.republish-format-tabs__button--active {
+	color: #333;
+	border: 1px solid #333;
+}
 
-	&.active {
-		display: block;
-	}
+.republish-content {
+	display: none;
+}
+
+.republish-content--active {
+	display: block;
 }
 
 .republish-content-container {
 	position: relative;
 }
 
-.republish-content-textarea {
+.republish-content__textarea {
+	margin: 1.5em 0;
 	width: 100%;
+}
+
+.plain-text-field {
+	margin-bottom: 1.5rem;
+}
+
+.plain-text-field__label {
+	display: block;
+	margin-bottom: 0.5rem;
+	font-weight: 600;
+	color: #333;
+}
+
+.plain-text-field__input {
+	width: 100%;
+	padding: 0.5rem;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 14px;
+	background-color: #f9f9f9;
+	margin-bottom: 0.5rem;
+
+	&:focus {
+		outline: none;
+		border-color: #007cba;
+		box-shadow: 0 0 0 1px #007cba;
+	}
+}
+
+.plain-text-field__button {
+	background: #007cba;
+	border: none;
+	color: white;
+	padding: 0.5rem 1rem;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 14px;
+	transition: background-color 0.2s;
+
+	&:hover {
+		background: #005a87;
+	}
+
+	&:focus {
+		outline: 2px solid #007cba;
+		outline-offset: 2px;
+	}
+}
+
+.republish-article__copy-button--main {
+	display: none;
+}
+
+.republish-article__copy-button--main.show-for-html {
+	display: inline-block;
 }

--- a/assets/republish-template.js
+++ b/assets/republish-template.js
@@ -62,15 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
 				return;
 			}
 
-			const success = copyTextToClipboard(activeTextarea.value);
-
-			if (success) {
-				event.target.innerText = "Copied!";
-
-				setTimeout(() => {
-					event.target.innerText = "Copy to clipboard";
-				}, 2000);
-			}
+			ClipboardUtils.copyFromElement(activeTextarea, event.target);
 		});
 
 	/**
@@ -82,48 +74,7 @@ document.addEventListener("DOMContentLoaded", () => {
 			event.preventDefault();
 
 			const targetSelector = button.getAttribute("data-target");
-			const targetElement = document.querySelector(targetSelector);
-
-			if (!targetElement) {
-				return;
-			}
-
-			// Get value from input or textarea
-			const value = targetElement.tagName.toLowerCase() === 'input' 
-				? targetElement.value 
-				: targetElement.textContent || targetElement.value;
-
-			const success = copyTextToClipboard(value);
-
-			if (success) {
-				const originalText = button.innerText;
-				button.innerText = "Copied!";
-
-				setTimeout(() => {
-					button.innerText = originalText;
-				}, 2000);
-			}
+			ClipboardUtils.copyFromElement(targetSelector, button);
 		});
 	});
-
-	/**
-	 * Copies the given text to the clipboard.
-	 *
-	 * @param {string} text The text to copy to the clipboard.
-	 *
-	 * @return {boolean} True if the text was copied to the clipboard, false otherwise.
-	 */
-	const copyTextToClipboard = (text) => {
-		// Check if the clipboard API is available.
-		if (!navigator.clipboard) {
-			return false;
-		}
-		// Copy the text to the clipboard.
-		navigator.clipboard
-			.writeText(text)
-			.then(() => true)
-			.catch(() => false);
-
-		return true;
-	};
 });

--- a/assets/republish-template.js
+++ b/assets/republish-template.js
@@ -7,33 +7,61 @@
  */
 document.addEventListener("DOMContentLoaded", () => {
 	/**
-	 * Selects the text in the textarea when it is focused.
+	 * Handle tab switching for format selection.
 	 */
-	document
-		.querySelector(".republish-article .republish-article__info textarea")
-		?.addEventListener("focus", (event) => {
-			event.target.select();
+	const tabButtons = document.querySelectorAll(".republish-tab-button");
+	const tabContents = document.querySelectorAll(".republish-tab-content");
+
+	tabButtons.forEach((button) => {
+		button.addEventListener("click", (event) => {
+			event.preventDefault();
+			const targetTab = button.getAttribute("data-tab");
+
+			tabButtons.forEach((btn) => btn.classList.remove("active"));
+			tabContents.forEach((content) => content.classList.remove("active"));
+
+			button.classList.add("active");
+			const targetContent = document.querySelector(`[data-tab-content="${targetTab}"]`);
+			if (targetContent) {
+				targetContent.classList.add("active");
+			}
 		});
+	});
 
 	/**
-	 * Copies the text in the textarea to the clipboard when the copy button is clicked.
+	 * Selects the text in the active textarea when it is focused.
+	 */
+	const textareas = document.querySelectorAll(".republish-article .republish-content-textarea");
+	textareas.forEach((textarea) => {
+		textarea.addEventListener("focus", (event) => {
+			event.target.select();
+		});
+	});
+
+	/**
+	 * Copies the text in the active textarea to the clipboard when the copy button is clicked.
 	 */
 	document
 		.querySelector(".republish-article .republish-article__copy-button")
 		?.addEventListener("click", (event) => {
 			event.preventDefault();
-			const textarea = document.querySelector(
-				".republish-article .republish-article__info textarea"
-			);
-			const success = copyTextToClipboard(textarea.value);
+
+			// Find the currently active textarea
+			const activeTextarea = document.querySelector(".republish-article .republish-tab-content.active") || document.querySelector(".republish-article .republish-content-textarea");
+
+			if (!activeTextarea) {
+				return;
+			}
+
+			const success = copyTextToClipboard(activeTextarea.value);
 
 			if (success) {
-				event.target.innerText = __("Copied!", "the-city-features");
+				event.target.innerText = __("Copied!", "republication-tracker-tool");
 
 				setTimeout(() => {
 					event.target.innerText = __(
 						"Copy to clipboard",
-						"the-city-features"
+						"republication-tracker-tool"
 					);
 				}, 2000);
 			}

--- a/assets/republish-template.js
+++ b/assets/republish-template.js
@@ -9,21 +9,31 @@ document.addEventListener("DOMContentLoaded", () => {
 	/**
 	 * Handle tab switching for format selection.
 	 */
-	const tabButtons = document.querySelectorAll(".republish-tab-button");
-	const tabContents = document.querySelectorAll(".republish-tab-content");
+	const tabButtons = document.querySelectorAll(".republish-format-tabs__button");
+	const tabContents = document.querySelectorAll(".republish-content");
 
 	tabButtons.forEach((button) => {
 		button.addEventListener("click", (event) => {
 			event.preventDefault();
 			const targetTab = button.getAttribute("data-tab");
 
-			tabButtons.forEach((btn) => btn.classList.remove("active"));
-			tabContents.forEach((content) => content.classList.remove("active"));
+			tabButtons.forEach((btn) => btn.classList.remove("republish-format-tabs__button--active"));
+			tabContents.forEach((content) => content.classList.remove("republish-content--active"));
 
-			button.classList.add("active");
+			button.classList.add("republish-format-tabs__button--active");
 			const targetContent = document.querySelector(`[data-tab-content="${targetTab}"]`);
 			if (targetContent) {
-				targetContent.classList.add("active");
+				targetContent.classList.add("republish-content--active");
+			}
+
+			// Show/hide main copy button based on active tab
+			const mainCopyButton = document.querySelector(".republish-article__copy-button--main");
+			if (mainCopyButton) {
+				if (targetTab === "html") {
+					mainCopyButton.classList.add("show-for-html");
+				} else {
+					mainCopyButton.classList.remove("show-for-html");
+				}
 			}
 		});
 	});
@@ -31,7 +41,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	/**
 	 * Selects the text in the active textarea when it is focused.
 	 */
-	const textareas = document.querySelectorAll(".republish-content-textarea");
+	const textareas = document.querySelectorAll(".republish-content__textarea");
 	textareas.forEach((textarea) => {
 		textarea.addEventListener("focus", (event) => {
 			event.target.select();
@@ -46,7 +56,7 @@ document.addEventListener("DOMContentLoaded", () => {
 		?.addEventListener("click", (event) => {
 			event.preventDefault();
 
-			const activeTextarea = document.querySelector(".republish-tab-content.active");
+			const activeTextarea = document.querySelector(".republish-content.republish-content--active.republish-content__textarea");
 
 			if (!activeTextarea) {
 				return;
@@ -62,6 +72,39 @@ document.addEventListener("DOMContentLoaded", () => {
 				}, 2000);
 			}
 		});
+
+	/**
+	 * Handle individual field copy buttons for plain text format.
+	 */
+	const copyFieldButtons = document.querySelectorAll(".plain-text-field__button");
+	copyFieldButtons.forEach((button) => {
+		button.addEventListener("click", (event) => {
+			event.preventDefault();
+
+			const targetSelector = button.getAttribute("data-target");
+			const targetElement = document.querySelector(targetSelector);
+
+			if (!targetElement) {
+				return;
+			}
+
+			// Get value from input or textarea
+			const value = targetElement.tagName.toLowerCase() === 'input' 
+				? targetElement.value 
+				: targetElement.textContent || targetElement.value;
+
+			const success = copyTextToClipboard(value);
+
+			if (success) {
+				const originalText = button.innerText;
+				button.innerText = "Copied!";
+
+				setTimeout(() => {
+					button.innerText = originalText;
+				}, 2000);
+			}
+		});
+	});
 
 	/**
 	 * Copies the given text to the clipboard.

--- a/assets/republish-template.js
+++ b/assets/republish-template.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", () => {
 	/**
 	 * Selects the text in the active textarea when it is focused.
 	 */
-	const textareas = document.querySelectorAll(".republish-article .republish-content-textarea");
+	const textareas = document.querySelectorAll(".republish-content-textarea");
 	textareas.forEach((textarea) => {
 		textarea.addEventListener("focus", (event) => {
 			event.target.select();
@@ -42,12 +42,11 @@ document.addEventListener("DOMContentLoaded", () => {
 	 * Copies the text in the active textarea to the clipboard when the copy button is clicked.
 	 */
 	document
-		.querySelector(".republish-article .republish-article__copy-button")
+		.querySelector(".republish-article__copy-button")
 		?.addEventListener("click", (event) => {
 			event.preventDefault();
 
-			// Find the currently active textarea
-			const activeTextarea = document.querySelector(".republish-article .republish-tab-content.active") || document.querySelector(".republish-article .republish-content-textarea");
+			const activeTextarea = document.querySelector(".republish-tab-content.active");
 
 			if (!activeTextarea) {
 				return;
@@ -56,13 +55,10 @@ document.addEventListener("DOMContentLoaded", () => {
 			const success = copyTextToClipboard(activeTextarea.value);
 
 			if (success) {
-				event.target.innerText = __("Copied!", "republication-tracker-tool");
+				event.target.innerText = "Copied!";
 
 				setTimeout(() => {
-					event.target.innerText = __(
-						"Copy to clipboard",
-						"republication-tracker-tool"
-					);
+					event.target.innerText = "Copy to clipboard";
 				}, 2000);
 			}
 		});

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -145,26 +145,35 @@
 
 .republish-format-tabs {
   display: flex;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .republish-format-tabs__button {
   background: none;
   border: none;
-  padding: 0.75rem 1.5rem;
+  padding: 1rem 1.5rem;
   cursor: pointer;
-  font-weight: 600;
+  font-weight: 500;
   color: #666;
+  position: relative;
+  transition: color 0.2s ease;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
 
   &:hover {
-    color: #333;
-    background-color: #f5f5f5;
+    color: #e0e0e0;
+  }
+
+  &:focus {
+    outline: none;
+    color: #e0e0e0;
   }
 }
 
 .republish-format-tabs__button--active {
   color: #333;
-  border: 1px solid #333;
+  border-bottom: 3px solid #333;
 }
 
 .republish-content {

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -78,7 +78,7 @@
   font-size: smaller;
   box-sizing: border-box;
   width: 100%;
-  margin: 0.5em 0 2em 0;
+  margin: 0.5em 0;
   cursor: auto;
   background-color: inherit;
   border-color: inherit;
@@ -148,7 +148,7 @@
   margin-bottom: 1rem;
 }
 
-.republish-tab-button {
+.republish-format-tabs__button {
   background: none;
   border: none;
   padding: 0.75rem 1.5rem;
@@ -160,25 +160,81 @@
     color: #333;
     background-color: #f5f5f5;
   }
-
-  &.active {
-    color: #333;
-    border: 1px solid #333;
-  }
 }
 
-.republish-tab-content {
-  display: none;
+.republish-format-tabs__button--active {
+  color: #333;
+  border: 1px solid #333;
+}
 
-  &.active {
-    display: block;
-  }
+.republish-content {
+  display: none;
+}
+
+.republish-content--active {
+  display: block;
 }
 
 .republish-content-container {
   position: relative;
 }
 
-.republish-content-textarea {
+.republish-content__textarea {
   width: 100%;
+}
+
+.plain-text-field {
+  margin-bottom: 1.5rem;
+}
+
+.plain-text-field__label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.plain-text-field__input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 14px;
+  background-color: #f9f9f9;
+  margin-bottom: 0.5rem;
+
+  &:focus {
+    outline: none;
+    border-color: #007cba;
+    box-shadow: 0 0 0 1px #007cba;
+  }
+}
+
+.plain-text-field__button {
+  background: #007cba;
+  border: none;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background: #005a87;
+  }
+
+  &:focus {
+    outline: 2px solid #007cba;
+    outline-offset: 2px;
+  }
+}
+
+.republication-tracker-tool__copy-button--main {
+  display: none;
+}
+
+.republication-tracker-tool__copy-button--main.show-for-html {
+  display: inline-block;
 }

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -160,6 +160,7 @@
   transition: color 0.2s ease;
   border-bottom: 2px solid transparent;
   border-radius: 0;
+  font-size: 20px;
 
   &:hover {
     color: #e0e0e0;
@@ -198,9 +199,10 @@
 
 .plain-text-field__label {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   font-weight: 600;
-  color: #333;
+  color: #1e1e1e;
+  font-size: 16px;
 }
 
 .plain-text-field__input {

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -5,247 +5,258 @@
  */
 .side-widget.republication_tracker_tool,
 .widget.republication_tracker_tool {
-  text-align: center;
-  max-width: 300px;
-  margin: 0 auto;
+	text-align: center;
+	max-width: 300px;
+	margin: 0 auto;
 }
 
 .side-widget.republication_tracker_tool p,
 .widget.republication_tracker_tool p {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 
 .side-widget.republication_tracker_tool a.license,
 .widget.republication_tracker_tool a.license {
-  border-top: 3px double #ddd;
-  border-bottom: 3px double #ddd;
-  padding: 1em 0;
-  min-width: 100%;
-  display: block;
+	border-top: 3px double #ddd;
+	border-bottom: 3px double #ddd;
+	padding: 1em 0;
+	min-width: 100%;
+	display: block;
 }
 
-.side-widget.republication_tracker_tool
-  button.republication-tracker-tool-button,
+.side-widget.republication_tracker_tool button.republication-tracker-tool-button,
 .widget.republication_tracker_tool button.republication-tracker-tool-button {
-  width: 100%;
-  background: #2a7ac2;
-  border: 1px solid #255b98;
-  color: #fff;
-  padding: 1em;
-  font-size: 1.25em;
-  margin: 0 0 1em 0;
-  display: block;
-  border-radius: 0.25em;
-  font-weight: bold;
-  text-shadow: 1px 1px 1px #255b98;
+	width: 100%;
+	background: #2a7ac2;
+	border: 1px solid #255b98;
+	color: #fff;
+	padding: 1em;
+	font-size: 1.25em;
+	margin: 0 0 1em 0;
+	display: block;
+	border-radius: 0.25em;
+	font-weight: bold;
+	text-shadow: 1px 1px 1px #255b98;
 }
 
-.side-widget.republication_tracker_tool
-  button.republication-tracker-tool-button:hover,
-.widget.republication_tracker_tool
-  button.republication-tracker-tool-button:hover {
-  background-color: #2863a7;
-  text-decoration: none;
-  cursor: pointer;
+.side-widget.republication_tracker_tool button.republication-tracker-tool-button:hover,
+.widget.republication_tracker_tool button.republication-tracker-tool-button:hover {
+	background-color: #2863a7;
+	text-decoration: none;
+	cursor: pointer;
 }
 
 #republication-tracker-tool-modal {
-  position: fixed;
-  z-index: 999999999;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.75);
+	position: fixed;
+	z-index: 999999999;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.75);
 }
 
 #republication-tracker-tool-modal-content {
-  position: absolute;
-  width: 90%;
-  max-width: 800px;
-  max-height: 90%;
-  overflow: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: #fff;
-  padding: 2em;
-  text-align: left;
+	position: absolute;
+	width: 90%;
+	max-width: 800px;
+	max-height: 90%;
+	overflow: auto;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background-color: #fff;
+	padding: 2em;
+	text-align: left;
+	border-radius: 0.25em;
 }
 
 #republication-tracker-tool-modal-content textarea {
-  font-family: monospace;
-  font-size: smaller;
-  box-sizing: border-box;
-  width: 100%;
-  margin: 0.5em 0;
-  cursor: auto;
-  background-color: inherit;
-  border-color: inherit;
+	font-family: monospace;
+	font-size: smaller;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0.5em 0;
+	cursor: auto;
+	background-color: inherit;
+	border-color: inherit;
 }
 
 #republication-tracker-tool-modal-content h2,
 #republication-tracker-tool-modal-content .cc-license,
 #republication-tracker-tool-modal-content .cc-policy {
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 1em;
+	border-bottom: 1px solid #ccc;
+	padding-bottom: 1em;
 }
 
 #republication-tracker-tool-modal-content .cc-license,
 #republication-tracker-tool-modal-content .cc-policy {
-  margin-bottom: 2em;
+	margin-bottom: 2em;
 }
 
 #republication-tracker-tool-modal-content .cc-license img {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 
 #republication-tracker-tool-modal-content .article-info h1 {
-  margin-bottom: 0;
+	margin-bottom: 0;
+}
+
+#republication-tracker-tool-modal-content .republish-modal-label {
+	margin-top: 0;
 }
 
 .republication-tracker-tool-close {
-  background: transparent !important;
-  border: 0 !important;
-  color: #000 !important;
-  padding: 0.5em !important;
-  position: absolute;
-  top: 0;
-  right: 0.5em;
-  font-family: sans-serif;
-  text-transform: lowercase;
-  font-size: 2em;
+	background: transparent !important;
+	border: 0 !important;
+	color: #000 !important;
+	font-size: 1rem;
+	padding: 0 !important;
+	position: absolute;
+	top: 0;
+	transition: all 125ms ease-in-out;
+	right: 0;
 }
 
 .republication-tracker-tool-close:hover {
-  cursor: pointer;
-  opacity: 0.8;
+	cursor: pointer;
+	opacity: 0.8;
+}
+
+.republication-tracker-tool-close-icon {
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M13.0597 12L19.5297 5.52997L18.4697 4.46997L11.9997 10.94L5.52973 4.46997L4.46973 5.52997L10.9397 12L4.46973 18.47L5.52973 19.53L11.9997 13.06L18.4697 19.53L19.5297 18.47L13.0597 12Z' fill='%231E1E1E'/%3E%3C/svg%3E");
+	background-position: center;
+	background-size: 24px 24px;
+	background-repeat: no-repeat;
+	display: block;
+	height: 2em;
+	width: 2em;
 }
 
 .modal-open-disallow-scrolling {
-  overflow: hidden;
+	overflow: hidden;
 }
 
 .republication_tracker_tool .license img {
-  width: 88px;
+	width: 88px;
 }
 
 .screen-reader-text {
-  border: 0;
-  clip: rect( 1px, 1px, 1px, 1px );
-  clip-path: inset( 50% );
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute !important;
-  width: 1px;
-  word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	border: 0;
+	clip: rect( 1px, 1px, 1px, 1px );
+	clip-path: inset( 50% );
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
 }
 
 .republish-format-tabs {
-  display: flex;
-  margin-bottom: 1.5rem;
-  border-bottom: 1px solid #e0e0e0;
+	display: flex;
+	margin-bottom: 1.5rem;
+	border-bottom: 1px solid #e0e0e0;
 }
 
 .republish-format-tabs__button {
-  background: none;
-  border: none;
-  padding: 1rem 1.5rem;
-  cursor: pointer;
-  font-weight: 500;
-  color: #666;
-  position: relative;
-  transition: color 0.2s ease;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  font-size: 20px;
+	background: none;
+	border: none;
+	padding: 1rem 1.5rem;
+	cursor: pointer;
+	font-weight: 500;
+	color: #666;
+	position: relative;
+	transition: color 0.2s ease;
+	border-bottom: 2px solid transparent;
+	border-radius: 0;
+	font-size: 20px;
 
-  &:hover {
-    color: #e0e0e0;
-  }
+	&:hover {
+		color: #e0e0e0;
+	}
 
-  &:focus {
-    outline: none;
-    color: #e0e0e0;
-  }
+	&:focus {
+		outline: none;
+		color: #e0e0e0;
+	}
 }
 
 .republish-format-tabs__button--active {
-  color: #333;
-  border-bottom: 3px solid #333;
+	color: #333;
+	border-bottom: 3px solid #333;
 }
 
 .republish-content {
-  display: none;
+	display: none;
 }
 
 .republish-content--active {
-  display: block;
+	display: block;
 }
 
 .republish-content-container {
-  position: relative;
+	position: relative;
 }
 
 .republish-content__textarea {
-  width: 100%;
+	width: 100%;
 }
 
 .plain-text-field {
-  margin-bottom: 1.5rem;
+	margin-bottom: 1.5rem;
 }
 
 .plain-text-field__label {
-  display: block;
-  margin-bottom: 0.75rem;
-  font-weight: 600;
-  color: #1e1e1e;
-  font-size: 16px;
+	display: block;
+	margin-bottom: 0.75rem;
+	font-weight: 600;
+	color: #1e1e1e;
+	font-size: 16px;
 }
 
 .plain-text-field__input {
-  width: 100%;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-family: monospace;
-  font-size: 14px;
-  background-color: #f9f9f9;
-  margin-bottom: 0.5rem;
+	width: 100%;
+	padding: 0.5rem;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 14px;
+	background-color: #fff;
+	margin-bottom: 0.5rem;
 
-  &:focus {
-    outline: none;
-    border-color: #007cba;
-    box-shadow: 0 0 0 1px #007cba;
-  }
+	&:focus {
+		outline: none;
+		border-color: #007cba;
+		box-shadow: 0 0 0 1px #007cba;
+	}
 }
 
 .plain-text-field__button {
-  background: #007cba;
-  border: none;
-  color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  transition: background-color 0.2s;
+	background: #007cba;
+	border: none;
+	color: white;
+	padding: 0.5rem 1rem;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 14px;
+	transition: background-color 0.2s;
 
-  &:hover {
-    background: #005a87;
-  }
+	&:hover {
+		background: #005a87;
+	}
 
-  &:focus {
-    outline: 2px solid #007cba;
-    outline-offset: 2px;
-  }
+	&:focus {
+		outline: 2px solid #007cba;
+		outline-offset: 2px;
+	}
 }
 
 .republication-tracker-tool__copy-button--main {
-  display: none;
+	display: none;
 }
 
 .republication-tracker-tool__copy-button--main.show-for-html {
-  display: inline-block;
+	display: inline-block;
 }

--- a/assets/widget.css
+++ b/assets/widget.css
@@ -142,3 +142,43 @@
   width: 1px;
   word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
 }
+
+.republish-format-tabs {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.republish-tab-button {
+  background: none;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  color: #666;
+
+  &:hover {
+    color: #333;
+    background-color: #f5f5f5;
+  }
+
+  &.active {
+    color: #333;
+    border: 1px solid #333;
+  }
+}
+
+.republish-tab-content {
+  display: none;
+
+  &.active {
+    display: block;
+  }
+}
+
+.republish-content-container {
+  position: relative;
+}
+
+.republish-content-textarea {
+  width: 100%;
+}

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -7,9 +7,36 @@ function copyToClipboard( element, button ) {
 	button.focus();
 }
 
+function copyFieldToClipboard( fieldSelector, button ) {
+	const $ = jQuery;
+	const $field = $( fieldSelector );
+
+	if ( $field.length === 0 ) {
+		return false;
+	}
+
+	const $temp = $( '<textarea>' );
+	$( 'body' ).append( $temp );
+	const value = $field.is( 'input' ) ? $field.val() : $field.text();
+	$temp.val( value ).select();
+
+	const success = document.execCommand( 'copy' );
+	$temp.remove();
+
+	if ( success && button ) {
+		const originalText = $( button ).text();
+		$( button ).text( 'Copied!' );
+		setTimeout( function() {
+			$( button ).text( originalText );
+		}, 2000 );
+	}
+
+	return success;
+}
+
 function getActiveTextarea() {
 	const $ = jQuery;
-	const $activeTextarea = $( '.republish-tab-content.active' );
+	const $activeTextarea = $( '.republish-content.republish-content--active textarea' );
 	if ( $activeTextarea.length > 0 ) {
 		return $activeTextarea;
 	}
@@ -19,15 +46,32 @@ function getActiveTextarea() {
 
 function initTabSwitching() {
 	const $ = jQuery;
-	$( '.republish-tab-button' ).on( 'click', function(e) {
+	$( '.republish-format-tabs__button' ).on( 'click', function(e) {
 		e.preventDefault();
 		const targetTab = $(this).attr('data-tab');
 
-		$( '.republish-tab-button' ).removeClass( 'active' );
-		$( '.republish-tab-content' ).removeClass( 'active' );
+		$( '.republish-format-tabs__button' ).removeClass( 'republish-format-tabs__button--active' );
+		$( '.republish-content' ).removeClass( 'republish-content--active' );
 
-		$( this ).addClass( 'active' );
-		$('[data-tab-content="' + targetTab + '"]').addClass( 'active' );
+		$( this ).addClass( 'republish-format-tabs__button--active' );
+		$('[data-tab-content="' + targetTab + '"]').addClass( 'republish-content--active' );
+
+		// Show/hide main copy button based on active tab
+		const $mainCopyButton = $( '.republication-tracker-tool__copy-button--main' );
+		if ( $mainCopyButton.length ) {
+			if ( targetTab === 'html' ) {
+				$mainCopyButton.addClass( 'show-for-html' );
+			} else {
+				$mainCopyButton.removeClass( 'show-for-html' );
+			}
+		}
+	} );
+
+	// Initialize copy buttons for individual fields
+	$( '.plain-text-field__button' ).on( 'click', function(e) {
+		e.preventDefault();
+		const target = $( this ).attr( 'data-target' );
+		copyFieldToClipboard( target, this );
 	} );
 }
 

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -7,6 +7,30 @@ function copyToClipboard( element, button ) {
 	button.focus();
 }
 
+function getActiveTextarea() {
+	const $ = jQuery;
+	const $activeTextarea = $( '.republish-tab-content.active' );
+	if ( $activeTextarea.length > 0 ) {
+		return $activeTextarea;
+	}
+	// Fallback to the original textarea if no tabs are present
+	return '#republication-tracker-tool-shareable-content';
+}
+
+function initTabSwitching() {
+	const $ = jQuery;
+	$( '.republish-tab-button' ).on( 'click', function(e) {
+		e.preventDefault();
+		const targetTab = $(this).attr('data-tab');
+
+		$( '.republish-tab-button' ).removeClass( 'active' );
+		$( '.republish-tab-content' ).removeClass( 'active' );
+
+		$( this ).addClass( 'active' );
+		$('[data-tab-content="' + targetTab + '"]').addClass( 'active' );
+	} );
+}
+
 function modal_actions(){
 	// Remove captions from shareable text
 	var $ = jQuery;
@@ -59,9 +83,12 @@ function show_modal( $modal, $close ) {
 	$modal.show();
 	$modal_content.show();
 	$('body').addClass('modal-open-disallow-scrolling');
-	$('#republication-tracker-tool-modal-content').unbind().click(function(e) {
+	$modal_content.unbind().click(function(e) {
 		e.stopPropagation();
 	});
+
+	initTabSwitching();
+
 	trapFocus( $modal );
 	$close.focus();
 }

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -1,47 +1,10 @@
-function copyToClipboard( element, button ) {
-	var $temp = jQuery( '<input>' );
-	jQuery( 'body' ).append( $temp );
-	$temp.val( jQuery( element ).text() ).select();
-	document.execCommand( 'copy' );
-	$temp.remove();
-	button.focus();
-}
-
-function copyFieldToClipboard( fieldSelector, button ) {
-	const $ = jQuery;
-	const $field = $( fieldSelector );
-
-	if ( $field.length === 0 ) {
-		return false;
-	}
-
-	const $temp = $( '<textarea>' );
-	$( 'body' ).append( $temp );
-	const value = $field.is( 'input' ) ? $field.val() : $field.text();
-	$temp.val( value ).select();
-
-	const success = document.execCommand( 'copy' );
-	$temp.remove();
-
-	if ( success && button ) {
-		const originalText = $( button ).text();
-		$( button ).text( 'Copied!' );
-		setTimeout( function() {
-			$( button ).text( originalText );
-		}, 2000 );
-	}
-
-	return success;
-}
-
 function getActiveTextarea() {
-	const $ = jQuery;
-	const $activeTextarea = $( '.republish-content.republish-content--active textarea' );
-	if ( $activeTextarea.length > 0 ) {
-		return $activeTextarea;
+	const activeTextarea = document.querySelector('.republish-content.republish-content--active textarea');
+	if (activeTextarea) {
+		return activeTextarea;
 	}
 	// Fallback to the original textarea if no tabs are present
-	return '#republication-tracker-tool-shareable-content';
+	return document.querySelector('#republication-tracker-tool-shareable-content');
 }
 
 function initTabSwitching() {
@@ -71,7 +34,7 @@ function initTabSwitching() {
 	$( '.plain-text-field__button' ).on( 'click', function(e) {
 		e.preventDefault();
 		const target = $( this ).attr( 'data-target' );
-		copyFieldToClipboard( target, this );
+		ClipboardUtils.copyFromElement( target, this );
 	} );
 }
 

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -17,8 +17,9 @@ class Republication_Tracker_Tool_Content {
 	 *
 	 * @param string $content The post content.
 	 * @param int    $post_id Optional. Current post ID by default.
+	 * @param bool   $escape_html Optional. Whether to escape HTML for final output. Default true.
 	 */
-	public static function get_republishable_content( $content, $post_id = false ) {
+	public static function get_republishable_content( $content, $post_id = false, $escape_html = true ) {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -72,8 +73,10 @@ class Republication_Tracker_Tool_Content {
 		// Remove non-distributable images.
 		$content = self::remove_non_distributable_images( $content, 'RTT removed image' );
 
-		// Force the content to be UTF-8 escaped HTML.
-		$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
+		// Force the content to be UTF-8 escaped HTML only if requested.
+		if ( $escape_html ) {
+			$content = htmlspecialchars( $content, ENT_HTML5, 'UTF-8', true );
+		}
 
 		$post_object = get_post( $post_id );
 
@@ -118,5 +121,147 @@ class Republication_Tracker_Tool_Content {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Generate plain text version of republishable content.
+	 *
+	 * @param WP_Post $post_object The post object.
+	 * @return string The plain text content.
+	 */
+	public static function get_republishable_plain_text_content( $post_object ) {
+		if ( ! $post_object instanceof WP_Post ) {
+			return '';
+		}
+
+		// Start building the plain text content
+		$plain_text_content = '';
+
+		// Get article metadata
+		$article_title    = get_the_title( $post_object );
+		$article_subtitle = get_post_meta( $post_object->ID, 'newspack_post_subtitle', true );
+		$author_byline    = apply_filters( 'republication_tracker_tool_byline', get_the_author_meta( 'display_name', $post_object->post_author ) );
+		$article_date     = date( 'F j, Y', strtotime( $post_object->post_date ) );
+		$canonical_url    = get_permalink( $post_object );
+
+		// Add the article title
+		if ( ! empty( $article_title ) ) {
+			$plain_text_content .= 'Title : ' . $article_title . "\n\n";
+		}
+
+		// Add the article subtitle
+		if ( ! empty( $article_subtitle ) ) {
+			$plain_text_content .= 'Subtitle : ' . $article_subtitle . "\n\n";
+		}
+
+		// Add the author byline (strip HTML tags)
+		if ( ! empty( $author_byline ) ) {
+			$plain_text_content .= 'Byline : ' . wp_strip_all_tags( $author_byline ) . "\n\n";
+		}
+
+		// Add the article date
+		if ( ! empty( $article_date ) ) {
+			$plain_text_content .= 'Date : ' . $article_date . "\n\n";
+		}
+
+		// Process the main content
+		if ( ! empty( $post_object->post_content ) ) {
+			// Get HTML content without escaping for plain text conversion
+			$html_content = self::get_republishable_content( $post_object->post_content, $post_object->ID, false );
+
+			// Convert HTML to plain text
+			$plain_content = self::convert_html_to_plain_text( $html_content );
+
+			$plain_text_content .= 'Content : ' .  $plain_content . "\n\n";
+		}
+
+		// Add attribution and licensing information
+		$site_name    = get_bloginfo( 'name' );
+		$license_key  = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+		$license_info = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ];
+
+		$plain_text_content .= "---\n\n";
+		$plain_text_content .= sprintf(
+			apply_filters( 'republication_tracker_tool_republish_plain_text_attribution',
+			// translators: %1$s is the site name, %2$s is the canonical URL, %3$s is the license description.
+			__( "This article originally appeared on %s (%s) and is republished here under a %s license.\n\n", 'republication-tracker-tool' ),
+			),
+			$site_name,
+			$canonical_url,
+			$license_info['description']
+		);
+
+		/**
+		 * Filters the plain text content of the republished post.
+		 *
+		 * @param string $plain_text_content The plain text content of the post.
+		 * @param WP_Post $post_object The post object.
+		 * @return string The filtered plain text content.
+		 */
+		$plain_text_content = apply_filters( 'republication_tracker_tool_republish_plain_text_content', $plain_text_content, $post_object );
+
+		return trim( $plain_text_content );
+	}
+
+	/**
+	 * Convert HTML content to formatted plain text.
+	 *
+	 * @param string $html_content The HTML content to convert.
+	 * @return string The converted plain text content.
+	 */
+	private static function convert_html_to_plain_text( $html_content ) {
+		$html_content = html_entity_decode( $html_content, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		// Remove unnecessary HTML tags
+		$html_content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $html_content );
+		$html_content = preg_replace( '/<img[^>]*>/i', '', $html_content );
+		$html_content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/is', "\n$1\n\n", $html_content );
+		$html_content = preg_replace( '/<p[^>]*>(.*?)<\/p>/is', "$1\n\n", $html_content );
+		$html_content = preg_replace( '/<br\s*\/?>/i', "\n", $html_content );
+
+		// ul to bullet points
+		$html_content = preg_replace_callback(
+			'/<ul[^>]*>(.*?)<\/ul>/is',
+			function( $matches ) {
+				$list_content = $matches[1];
+				// Convert each list item to a bullet point
+				$list_content = preg_replace( '/<li[^>]*>(.*?)<\/li>/is', "• $1\n", $list_content );
+				return "\n" . $list_content . "\n";
+			},
+			$html_content
+		);
+
+		// ol to numbered points
+		$html_content = preg_replace_callback(
+			'/<ol[^>]*>(.*?)<\/ol>/is',
+			function( $matches ) {
+				$list_content = $matches[1];
+				$counter = 1;
+				// Convert each list item to a numbered point
+				$list_content = preg_replace_callback(
+					'/<li[^>]*>(.*?)<\/li>/is',
+					function( $item_matches ) use ( &$counter ) {
+						return $counter++ . ". " . $item_matches[1] . "\n";
+					},
+					$list_content
+				);
+				return "\n" . $list_content . "\n";
+			},
+			$html_content
+		);
+
+		// Handle tags containing information
+		$html_content = preg_replace( '/<blockquote[^>]*>(.*?)<\/blockquote>/is', "\n> $1\n\n", $html_content );
+		$html_content = preg_replace( '/<a[^>]*>(.*?)<\/a>/is', '$1', $html_content );
+		$html_content = preg_replace( '/<(strong|b)[^>]*>(.*?)<\/\1>/is', '$2', $html_content );
+		$html_content = preg_replace( '/<(em|i)[^>]*>(.*?)<\/\1>/is', '$2', $html_content );
+
+		// Remove all remaining HTML tags
+		$plain_text = wp_strip_all_tags( $html_content );
+		$plain_text = preg_replace( '/\n\s*\n\s*\n/', "\n\n", $plain_text );
+		$plain_text = preg_replace( '/[ \t]+/', ' ', $plain_text );
+		$plain_text = preg_replace( '/^\s+|\s+$/m', '', $plain_text );
+
+		return trim( $plain_text );
 	}
 }

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -142,7 +142,6 @@ class Republication_Tracker_Tool_Content {
 		$article_subtitle = get_post_meta( $post_object->ID, 'newspack_post_subtitle', true );
 		$author_byline    = apply_filters( 'republication_tracker_tool_byline', get_the_author_meta( 'display_name', $post_object->post_author ) );
 		$article_date     = date( 'F j, Y', strtotime( $post_object->post_date ) );
-		$canonical_url    = get_permalink( $post_object );
 
 		// Add the article title
 		if ( ! empty( $article_title ) ) {
@@ -174,22 +173,6 @@ class Republication_Tracker_Tool_Content {
 
 			$plain_text_content .= "Content : \n\n" .  $plain_content . "\n\n";
 		}
-
-		// Add attribution and licensing information
-		$site_name    = get_bloginfo( 'name' );
-		$license_key  = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
-		$license_info = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ];
-
-		$plain_text_content .= "---\n\n";
-		$plain_text_content .= sprintf(
-			apply_filters( 'republication_tracker_tool_republish_plain_text_attribution',
-			// translators: %1$s is the site name, %2$s is the canonical URL, %3$s is the license description.
-			__( "This article originally appeared on %s (%s) and is republished here under a %s license.\n\n", 'republication-tracker-tool' ),
-			),
-			$site_name,
-			$canonical_url,
-			$license_info['description']
-		);
 
 		/**
 		 * Filters the plain text content of the republished post.

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -138,29 +138,23 @@ class Republication_Tracker_Tool_Content {
 		$plain_text_content = '';
 
 		// Get article metadata
-		$article_title    = get_the_title( $post_object );
-		$article_subtitle = get_post_meta( $post_object->ID, 'newspack_post_subtitle', true );
-		$author_byline    = apply_filters( 'republication_tracker_tool_byline', get_the_author_meta( 'display_name', $post_object->post_author ) );
-		$article_date     = date( 'F j, Y', strtotime( $post_object->post_date ) );
+		$article_title = get_the_title( $post_object );
+		$author_byline = sprintf( '%1$s, %2$s', apply_filters( 'republication_tracker_tool_byline', __( 'By ', 'republication-tracker-tool' ) . get_the_author_meta( 'display_name', $post_object->post_author ) ), get_bloginfo( 'name' ) );
+		$article_date  = date( 'F j, Y', strtotime( $post_object->post_date ) );
 
 		// Add the article title
 		if ( ! empty( $article_title ) ) {
-			$plain_text_content .= 'Title : ' . $article_title . "\n\n";
-		}
-
-		// Add the article subtitle
-		if ( ! empty( $article_subtitle ) ) {
-			$plain_text_content .= 'Subtitle : ' . $article_subtitle . "\n\n";
+			$plain_text_content .= $article_title . "\n\n";
 		}
 
 		// Add the author byline (strip HTML tags)
 		if ( ! empty( $author_byline ) ) {
-			$plain_text_content .= 'Byline : ' . wp_strip_all_tags( $author_byline ) . "\n\n";
+			$plain_text_content .= wp_strip_all_tags( $author_byline ) . "\n";
 		}
 
 		// Add the article date
 		if ( ! empty( $article_date ) ) {
-			$plain_text_content .= 'Date : ' . $article_date . "\n\n";
+			$plain_text_content .= $article_date . "\n\n";
 		}
 
 		// Process the main content
@@ -171,7 +165,7 @@ class Republication_Tracker_Tool_Content {
 			// Convert HTML to plain text
 			$plain_content = self::convert_html_to_plain_text( $html_content );
 
-			$plain_text_content .= "Content : \n\n" .  $plain_content . "\n\n";
+			$plain_text_content .= $plain_content . "\n\n";
 		}
 
 		/**

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -172,7 +172,7 @@ class Republication_Tracker_Tool_Content {
 			// Convert HTML to plain text
 			$plain_content = self::convert_html_to_plain_text( $html_content );
 
-			$plain_text_content .= 'Content : ' .  $plain_content . "\n\n";
+			$plain_text_content .= "Content : \n\n" .  $plain_content . "\n\n";
 		}
 
 		// Add attribution and licensing information
@@ -212,7 +212,7 @@ class Republication_Tracker_Tool_Content {
 	private static function convert_html_to_plain_text( $html_content ) {
 		$html_content = html_entity_decode( $html_content, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
 
-		// Remove unnecessary HTML tags
+		// Filter tags and clean up the content.
 		$html_content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $html_content );
 		$html_content = preg_replace( '/<img[^>]*>/i', '', $html_content );
 		$html_content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/is', "\n$1\n\n", $html_content );
@@ -260,7 +260,6 @@ class Republication_Tracker_Tool_Content {
 		$plain_text = wp_strip_all_tags( $html_content );
 		$plain_text = preg_replace( '/\n\s*\n\s*\n/', "\n\n", $plain_text );
 		$plain_text = preg_replace( '/[ \t]+/', ' ', $plain_text );
-		$plain_text = preg_replace( '/^\s+|\s+$/m', '', $plain_text );
 
 		return trim( $plain_text );
 	}

--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -168,6 +168,19 @@ class Republication_Tracker_Tool_Content {
 			$plain_text_content .= $plain_content . "\n\n";
 		}
 
+		// Add attribution.
+		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
+		if ( 'on' === $display_attribution ) {
+			$license_key         = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+			$license_description = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'];
+			$plain_text_content .= "\n" . sprintf(
+				// translators: %1$s is the site name, %2$s is the license description.
+				esc_html__( 'This article first appeared on %1$s and is republished here under a %2$s.', 'republication-tracker-tool' ),
+				get_bloginfo( 'name' ),
+				$license_description
+			) . "\n\n";
+		}
+
 		/**
 		 * Filters the plain text content of the republished post.
 		 *

--- a/includes/class-republication-rewrite.php
+++ b/includes/class-republication-rewrite.php
@@ -161,11 +161,20 @@ class Republication_Tracker_Tool_Rewrite_Endpoint {
 			REPUBLICATION_TRACKER_TOOL_VERSION
 		);
 
+		// Enqueue the clipboard utility first
+		wp_enqueue_script(
+			'republication-tracker-tool-clipboard-utils',
+			REPUBLICATION_TRACKER_TOOL_URL . 'assets/clipboard-utils.js',
+			array(),
+			REPUBLICATION_TRACKER_TOOL_VERSION,
+			true
+		);
+
 		// Enqueue the republish page scripts.
 		wp_enqueue_script(
 			'republication-tracker-tool-republish-template',
 			REPUBLICATION_TRACKER_TOOL_URL . 'assets/republish-template.js',
-			array(),
+			array( 'republication-tracker-tool-clipboard-utils' ),
 			REPUBLICATION_TRACKER_TOOL_VERSION,
 			true
 		);

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -92,6 +92,11 @@ class Republication_Tracker_Tool_Settings {
 				'label'    => esc_html__( 'Hide republication widgets on posts by default', 'republication-tracker-tool' ),
 				'callback' => array( $this, 'republication_tracker_tool_default_post_distribution_callback' ),
 			],
+			[
+				'key'      => 'republication_tracker_tool_enable_plain_text',
+				'label'    => esc_html__( 'Enable plain text option', 'republication-tracker-tool' ),
+				'callback' => array( $this, 'republication_tracker_tool_enable_plain_text_callback' ),
+			],
 		];
 		foreach ( $settings as $setting ) {
 			add_settings_field(
@@ -284,6 +289,24 @@ class Republication_Tracker_Tool_Settings {
 				<?php endif; ?>
 			/>
 			<p><em><?php echo esc_html__( 'If checked, "Hide Republication Widget" will be enabled by default for new posts.', 'republication-tracker-tool' ); ?></em></p>
+		<?php
+	}
+
+	public function republication_tracker_tool_enable_plain_text_callback() {
+		$enable_plain_text = get_option( 'republication_tracker_tool_enable_plain_text', 'off' );
+		?>
+			<input
+				type="checkbox"
+				id="<?php echo esc_attr( 'republication_tracker_tool_enable_plain_text' ); ?>"
+				name="<?php echo esc_attr( 'republication_tracker_tool_enable_plain_text' ); ?>"
+				<?php if ( 'on' === $enable_plain_text ) : ?>
+					checked
+				<?php endif; ?>
+			/>
+			<label for="<?php echo esc_attr( 'republication_tracker_tool_enable_plain_text' ); ?>">
+				<?php echo esc_html__( 'Offer plain text version alongside HTML', 'republication-tracker-tool' ); ?>
+			</label>
+			<p><em><?php echo esc_html__( 'If checked, users will be able to copy both HTML and plain text versions of the republishable content.', 'republication-tracker-tool' ); ?></em></p>
 		<?php
 	}
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -358,4 +358,14 @@ class Republication_Tracker_Tool_Settings {
 
 		return wp_kses( $content, $allowed_html );
 	}
+
+	/**
+	 * Check if plain text content feature is enabled.
+	 *
+	 * @return bool True if plain text content is enabled, false otherwise.
+	 */
+	public static function is_plain_text_enabled() {
+		$enable_plain_text = get_option( 'republication_tracker_tool_enable_plain_text', 'off' );
+		return 'on' === $enable_plain_text;
+	}
 }

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -55,7 +55,8 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		$is_amp = self::is_amp();
 
 		if ( ! $is_amp ) {
-			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
+			wp_enqueue_script( 'republication-tracker-tool-clipboard-utils', plugins_url( 'assets/clipboard-utils.js', dirname( __FILE__ ) ), array(), filemtime( plugin_dir_path( __FILE__ ) ), false );
+			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery', 'republication-tracker-tool-clipboard-utils' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
 		}
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), filemtime( plugin_dir_path(__FILE__) ) );
 

--- a/includes/licenses.php
+++ b/includes/licenses.php
@@ -40,7 +40,7 @@ const REPUBLICATION_TRACKER_TOOL_LICENSES = [
 	],
 	'cc-zero-1.0' => [
 		'label' => 'CC0 1.0',
-		'description' => 'CC0 1.0 Universal',
+		'description' => 'CC0 1.0 Universal License',
 		'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
 		'badge' => 'https://licensebuttons.net/l/zero/1.0/88x31.png'
 	],

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -54,6 +54,7 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
 $plain_text_content = '';
 if ( $plain_text_enabled ) {
+	$canonical_tag      = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
 	$plain_text_content = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
 }
 
@@ -98,10 +99,10 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			<div class="republication-content-section">
 				<?php if ( $plain_text_enabled ) : ?>
 					<div class="republish-format-tabs">
-						<button class="republish-tab-button active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
+						<button class="republish-format-tabs__button republish-format-tabs__button--active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
 							<?php esc_html_e( 'HTML', 'republication-tracker-tool' ); ?>
 						</button>
-						<button class="republish-tab-button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
+						<button class="republish-format-tabs__button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
 							<?php esc_html_e( 'Plain Text', 'republication-tracker-tool' ); ?>
 						</button>
 					</div>
@@ -110,7 +111,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 				<div class="republish-content-container">
 					<textarea
 						id="republication-tracker-tool-shareable-content"
-						class="republish-content-textarea <?php echo $plain_text_enabled ? 'republish-tab-content active' : ''; ?>"
+						class="republish-content__textarea <?php echo $plain_text_enabled ? 'republish-content republish-content--active' : ''; ?>"
 						data-tab-content="html"
 						readonly
 						rows="5"
@@ -118,21 +119,63 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 					><?php echo esc_html( $article_info ); ?><?php echo $content; ?><?php echo htmlspecialchars( $content_footer, ENT_QUOTES, 'UTF-8' ); ?></textarea>
 
 					<?php if ( $plain_text_enabled ) : ?>
-						<textarea
-							id="republication-tracker-tool-shareable-content-plain-text"
-							class="republish-content-textarea republish-tab-content"
-							data-tab-content="plain-text"
-							readonly
-							rows="5"
-							aria-label="<?php esc_attr_e( 'Republish this article (Plain text format)', 'republication-tracker-tool' ); ?>"
-						><?php echo esc_html( $plain_text_content ); ?></textarea>
+						<div class="republish-content" data-tab-content="plain-text">
+							<div class="plain-text-field">
+								<label class="plain-text-field__label" for="republication-tracker-tool-canonical-url">
+									<strong><?php esc_html_e( 'Canonical Tag:', 'republication-tracker-tool' ); ?></strong>
+								</label>
+								<input
+									type="text"
+									id="republication-tracker-tool-canonical-url"
+									class="plain-text-field__input"
+									readonly
+									value="<?php echo esc_html( $canonical_tag ); ?>"
+									aria-label="<?php esc_attr_e( 'Canonical tag for this article', 'republication-tracker-tool' ); ?>"
+								/>
+								<button class="plain-text-field__button" data-target="#republication-tracker-tool-canonical-url" aria-label="<?php esc_attr_e( 'Copy canonical URL', 'republication-tracker-tool' ); ?>">
+									<?php esc_html_e( 'Copy Tag', 'republication-tracker-tool' ); ?>
+								</button>
+							</div>
+
+							<div class="plain-text-field">
+								<label class="plain-text-field__label" for="republication-tracker-tool-plain-text-content">
+									<strong><?php esc_html_e( 'Article Content:', 'republication-tracker-tool' ); ?></strong>
+								</label>
+								<textarea
+									id="republication-tracker-tool-plain-text-content"
+									class="republish-content__textarea"
+									readonly
+									rows="8"
+									aria-label="<?php esc_attr_e( 'Plain text article content', 'republication-tracker-tool' ); ?>"
+								><?php echo $plain_text_content ?></textarea>
+								<button class="plain-text-field__button" data-target="#republication-tracker-tool-plain-text-content" aria-label="<?php esc_attr_e( 'Copy article content', 'republication-tracker-tool' ); ?>">
+									<?php esc_html_e( 'Copy Content', 'republication-tracker-tool' ); ?>
+								</button>
+							</div>
+
+							<div class="plain-text-field">
+								<label class="plain-text-field__label" for="republication-tracker-tool-tracking-snippet">
+									<strong><?php esc_html_e( 'Attribution & Tracking:', 'republication-tracker-tool' ); ?></strong>
+								</label>
+								<textarea
+									id="republication-tracker-tool-tracking-snippet"
+									class="republish-content__textarea"
+									readonly
+									rows="3"
+									aria-label="<?php esc_attr_e( 'Attribution and tracking snippet', 'republication-tracker-tool' ); ?>"
+								><?php echo $content_footer ?></textarea>
+								<button class="plain-text-field__button" data-target="#republication-tracker-tool-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
+									<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>
+								</button>
+							</div>
+						</div>
 					<?php endif; ?>
 				</div>
 			</div>
 			<?php
 			if ( ! $is_amp ) {
 				?>
-			<button onclick="copyToClipboard( getActiveTextarea(), this )"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+			<button onclick="copyToClipboard( getActiveTextarea(), this )" class="republication-tracker-tool__copy-button republication-tracker-tool__copy-button--main show-for-html"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 				<?php
 			}
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -54,8 +54,9 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
 $plain_text_content = '';
 if ( $plain_text_enabled ) {
-	$canonical_tag      = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
-	$plain_text_content = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
+	$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
+	$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
+	$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
 }
 
 /**
@@ -157,13 +158,14 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 								<label class="plain-text-field__label" for="republication-tracker-tool-tracking-snippet">
 									<strong><?php esc_html_e( 'Attribution & Tracking:', 'republication-tracker-tool' ); ?></strong>
 								</label>
-								<textarea
+								<input
+									type="text"
 									id="republication-tracker-tool-tracking-snippet"
-									class="republish-content__textarea"
+									class="plain-text-field__input"
 									readonly
-									rows="3"
 									aria-label="<?php esc_attr_e( 'Attribution and tracking snippet', 'republication-tracker-tool' ); ?>"
-								><?php echo $content_footer ?></textarea>
+									value="<?php echo esc_html( $additional_tracking_html ); ?>"
+								/>
 								<button class="plain-text-field__button" data-target="#republication-tracker-tool-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
 									<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>
 								</button>

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -175,7 +175,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			<?php
 			if ( ! $is_amp ) {
 				?>
-			<button onclick="copyToClipboard( getActiveTextarea(), this )" class="republication-tracker-tool__copy-button republication-tracker-tool__copy-button--main show-for-html"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+			<button onclick="ClipboardUtils.copyFromElement( getActiveTextarea(), this )" class="republication-tracker-tool__copy-button republication-tracker-tool__copy-button--main show-for-html"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 				<?php
 			}
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -51,7 +51,11 @@ $article_info = sprintf(
 $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 
 // Check if plain text feature is enabled
+$plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
 $plain_text_content = '';
+if ( $plain_text_enabled ) {
+	$plain_text_content = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
+}
 
 /**
  * The licensing statement from this plugin

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -50,6 +50,9 @@ $article_info = sprintf(
 // strip empty tags after automatically applying p tags.
 $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 
+// Check if plain text feature is enabled
+$plain_text_content = '';
+
 /**
  * The licensing statement from this plugin
  *
@@ -88,16 +91,44 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 
 			// the text area that is copyable
 			?>
-				<textarea readonly id="republication-tracker-tool-shareable-content" rows="5">
-					<?php echo esc_html( $article_info ); ?>
-					<?php echo $content; ?>
+			<div class="republication-content-section">
+				<?php if ( $plain_text_enabled ) : ?>
+					<div class="republish-format-tabs">
+						<button class="republish-tab-button active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
+							<?php esc_html_e( 'HTML', 'republication-tracker-tool' ); ?>
+						</button>
+						<button class="republish-tab-button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
+							<?php esc_html_e( 'Plain Text', 'republication-tracker-tool' ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
 
-					<?php echo htmlspecialchars( $content_footer, ENT_QUOTES, 'UTF-8' ); ?>
-				</textarea>
+				<div class="republish-content-container">
+					<textarea
+						id="republication-tracker-tool-shareable-content"
+						class="republish-content-textarea <?php echo $plain_text_enabled ? 'republish-tab-content active' : ''; ?>"
+						data-tab-content="html"
+						readonly
+						rows="5"
+						aria-label="<?php esc_attr_e( 'Republish this article (HTML format)', 'republication-tracker-tool' ); ?>"
+					><?php echo esc_html( $article_info ); ?><?php echo $content; ?><?php echo htmlspecialchars( $content_footer, ENT_QUOTES, 'UTF-8' ); ?></textarea>
+
+					<?php if ( $plain_text_enabled ) : ?>
+						<textarea
+							id="republication-tracker-tool-shareable-content-plain-text"
+							class="republish-content-textarea republish-tab-content"
+							data-tab-content="plain-text"
+							readonly
+							rows="5"
+							aria-label="<?php esc_attr_e( 'Republish this article (Plain text format)', 'republication-tracker-tool' ); ?>"
+						><?php echo esc_html( $plain_text_content ); ?></textarea>
+					<?php endif; ?>
+				</div>
+			</div>
 			<?php
 			if ( ! $is_amp ) {
 				?>
-			<button onclick="copyToClipboard('#republication-tracker-tool-shareable-content', this)"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
+			<button onclick="copyToClipboard( getActiveTextarea(), this )"><?php echo esc_html__( 'Copy to Clipboard', 'republication-tracker-tool' ); ?></button>
 				<?php
 			}
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -69,7 +69,7 @@ $license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_T
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
-	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
+	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span><span class="republication-tracker-tool-close-icon"></span></button>';
 	printf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
 	// Explain Creative Commons

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -231,7 +231,7 @@ if ( $plain_text_enabled ) {
 										<input
 											type="text"
 											id="republish-canonical-url"
-											class="republish-content__textarea"
+											class="republish-content__input"
 											readonly
 											value="<?php echo esc_html( $canonical_tag ); ?>"
 											aria-label="<?php esc_attr_e( 'Canonical Tag for this article', 'republication-tracker-tool' ); ?>"
@@ -264,7 +264,7 @@ if ( $plain_text_enabled ) {
 										<input
 											type="text"
 											id="republish-tracking-snippet"
-											class="republish-content__textarea"
+											class="republish-content__input"
 											readonly
 											aria-label="<?php esc_attr_e( 'Tracking snippet', 'republication-tracker-tool' ); ?>"
 											value="<?php echo esc_html( $additional_tracking_html ); ?>"

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -157,6 +157,7 @@ $plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled
 $republish_plain_text_content = '';
 if ( $plain_text_enabled ) {
 	$republish_plain_text_content = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post_object );
+	$additional_tracking_html     = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post_object->ID );
 }
 ?>
 
@@ -251,15 +252,16 @@ if ( $plain_text_enabled ) {
 
 									<div class="plain-text-field">
 										<label class="plain-text-field__label" for="republish-tracking-snippet">
-											<strong><?php esc_html_e( 'Attribution & Tracking:', 'republication-tracker-tool' ); ?></strong>
+											<strong><?php esc_html_e( 'Tracking Snippet:', 'republication-tracker-tool' ); ?></strong>
 										</label>
-										<textarea
+										<input
+											type="text"
 											id="republish-tracking-snippet"
 											class="republish-content__textarea"
 											readonly
-											rows="4"
-											aria-label="<?php esc_attr_e( 'Attribution and tracking snippet', 'republication-tracker-tool' ); ?>"
-										><?php echo $content_footer ?></textarea>
+											aria-label="<?php esc_attr_e( 'Tracking snippet', 'republication-tracker-tool' ); ?>"
+											value="<?php echo esc_html( $additional_tracking_html ); ?>"
+										/>
 										<button class="plain-text-field__button" data-target="#republish-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
 											<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>
 										</button>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -194,10 +194,10 @@ if ( $plain_text_enabled ) {
 					<section class="republish-article__info">
 						<?php if ( $plain_text_enabled ) : ?>
 							<div class="republish-format-tabs">
-								<button class="republish-tab-button active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
+								<button class="republish-format-tabs__button republish-format-tabs__button--active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
 									<?php esc_html_e( 'HTML', 'republication-tracker-tool' ); ?>
 								</button>
-								<button class="republish-tab-button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
+								<button class="republish-format-tabs__button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
 									<?php esc_html_e( 'Plain Text', 'republication-tracker-tool' ); ?>
 								</button>
 							</div>
@@ -206,7 +206,7 @@ if ( $plain_text_enabled ) {
 						<div class="republish-content-container">
 							<textarea
 								id="republish-html-content"
-								class="republish-content-textarea <?php echo $plain_text_enabled ? 'republish-tab-content active' : ''; ?>"
+								class="republish-content__textarea <?php echo $plain_text_enabled ? 'republish-content republish-content--active' : ''; ?>"
 								data-tab-content="html"
 								rows="19"
 								readonly
@@ -215,19 +215,60 @@ if ( $plain_text_enabled ) {
 							><?php echo esc_html( $republish_content ); ?></textarea>
 
 							<?php if ( $plain_text_enabled ) : ?>
-								<textarea
-									id="republish-plain-text-content"
-									class="republish-content-textarea republish-tab-content"
-									data-tab-content="plain-text"
-									rows="19"
-									readonly
-									aria-readonly="true"
-									aria-label="<?php esc_attr_e( 'Republish this article (Plain text format)', 'republication-tracker-tool' ); ?>"
-								><?php echo esc_html( $republish_plain_text_content ); ?></textarea>
+								<div class="republish-content" data-tab-content="plain-text">
+									<div class="plain-text-field">
+										<label class="plain-text-field__label" for="republish-canonical-url">
+											<strong><?php esc_html_e( 'Canonical Tag:', 'republication-tracker-tool' ); ?></strong>
+										</label>
+										<input
+											type="text"
+											id="republish-canonical-url"
+											class="republish-content__textarea"
+											readonly
+											value="<?php echo esc_html( $canonical_tag ); ?>"
+											aria-label="<?php esc_attr_e( 'Canonical Tag for this article', 'republication-tracker-tool' ); ?>"
+										/>
+										<button class="plain-text-field__button" data-target="#republish-canonical-url" aria-label="<?php esc_attr_e( 'Copy canonical URL', 'republication-tracker-tool' ); ?>">
+											<?php esc_html_e( 'Copy Tag', 'republication-tracker-tool' ); ?>
+										</button>
+									</div>
+
+									<div class="plain-text-field">
+										<label class="plain-text-field__label" for="republish-plain-text-content">
+											<strong><?php esc_html_e( 'Article Content:', 'republication-tracker-tool' ); ?></strong>
+										</label>
+										<textarea
+											id="republish-plain-text-content"
+											class="republish-content__textarea"
+											readonly
+											rows="12"
+											aria-label="<?php esc_attr_e( 'Plain text article content', 'republication-tracker-tool' ); ?>"
+										><?php echo $republish_plain_text_content; ?></textarea>
+										<button class="plain-text-field__button" data-target="#republish-plain-text-content" aria-label="<?php esc_attr_e( 'Copy article content', 'republication-tracker-tool' ); ?>">
+											<?php esc_html_e( 'Copy Content', 'republication-tracker-tool' ); ?>
+										</button>
+									</div>
+
+									<div class="plain-text-field">
+										<label class="plain-text-field__label" for="republish-tracking-snippet">
+											<strong><?php esc_html_e( 'Attribution & Tracking:', 'republication-tracker-tool' ); ?></strong>
+										</label>
+										<textarea
+											id="republish-tracking-snippet"
+											class="republish-content__textarea"
+											readonly
+											rows="4"
+											aria-label="<?php esc_attr_e( 'Attribution and tracking snippet', 'republication-tracker-tool' ); ?>"
+										><?php echo $content_footer ?></textarea>
+										<button class="plain-text-field__button" data-target="#republish-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
+											<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>
+										</button>
+									</div>
+								</div>
 							<?php endif; ?>
 						</div>
 
-						<button class="republish-article__copy-button" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">
+						<button class="republish-article__copy-button republish-article__copy-button--main show-for-html" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">
 							<?php esc_html_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>
 						</button>
 					</section>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -38,7 +38,14 @@ $article_title = get_the_title( $republish_post_id );
 $article_subtitle = get_post_meta( $republish_post_id, 'newspack_post_subtitle', true );
 
 // Get article author byline.
-$author_byline = apply_filters( 'republication_tracker_tool_author_byline', '', $republish_post_id );
+$author_byline = apply_filters(
+	'republication_tracker_tool_author_byline',
+	sprintf(
+		'%1$s, %2$s',
+		__( 'By ', 'republication-tracker-tool' ) . get_the_author_meta( 'display_name', $post_object->post_author ),
+		get_bloginfo( 'name' )
+	)
+);
 
 // Get article date and time in current timezone.
 $article_date_gmt = get_post_time( 'U', true, $republish_post_id ); // Get post date in GMT.
@@ -95,7 +102,7 @@ if ( ! empty( $article_subtitle ) ) {
 // Add the article author to the republish content.
 if ( ! empty( $author_byline ) ) {
 	$republish_content .= sprintf(
-		"\n\n<div>%s</div>",
+		"\n\n<p class='byline'>%s</p>",
 		$author_byline
 	);
 }

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -151,6 +151,13 @@ $republish_content = preg_replace( '/ sizes=".*?"/', '', $republish_content );
 
 // Filter the republish content.
 $republish_content = apply_filters( 'republication_tracker_tool_republish_article_markup', $republish_content, $post_object );
+
+// Generate plain text content if the feature is enabled.
+$plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
+$republish_plain_text_content = '';
+if ( $plain_text_enabled ) {
+	$republish_plain_text_content = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post_object );
+}
 ?>
 
 <section id="primary" class="content-area">
@@ -185,7 +192,41 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 				<?php endif; ?>
 				<div class="republish-article__content">
 					<section class="republish-article__info">
-						<textarea rows="19" readonly aria-readonly="true" aria-label="<?php esc_attr_e( 'Republish this article', 'republication-tracker-tool' ); ?>"><?php echo esc_html( $republish_content ); ?></textarea>
+						<?php if ( $plain_text_enabled ) : ?>
+							<div class="republish-format-tabs">
+								<button class="republish-tab-button active" data-tab="html" aria-label="<?php esc_attr_e( 'HTML format', 'republication-tracker-tool' ); ?>">
+									<?php esc_html_e( 'HTML', 'republication-tracker-tool' ); ?>
+								</button>
+								<button class="republish-tab-button" data-tab="plain-text" aria-label="<?php esc_attr_e( 'Plain text format', 'republication-tracker-tool' ); ?>">
+									<?php esc_html_e( 'Plain Text', 'republication-tracker-tool' ); ?>
+								</button>
+							</div>
+						<?php endif; ?>
+
+						<div class="republish-content-container">
+							<textarea
+								id="republish-html-content"
+								class="republish-content-textarea <?php echo $plain_text_enabled ? 'republish-tab-content active' : ''; ?>"
+								data-tab-content="html"
+								rows="19"
+								readonly
+								aria-readonly="true"
+								aria-label="<?php esc_attr_e( 'Republish this article (HTML format)', 'republication-tracker-tool' ); ?>"
+							><?php echo esc_html( $republish_content ); ?></textarea>
+
+							<?php if ( $plain_text_enabled ) : ?>
+								<textarea
+									id="republish-plain-text-content"
+									class="republish-content-textarea republish-tab-content"
+									data-tab-content="plain-text"
+									rows="19"
+									readonly
+									aria-readonly="true"
+									aria-label="<?php esc_attr_e( 'Republish this article (Plain text format)', 'republication-tracker-tool' ); ?>"
+								><?php echo esc_html( $republish_plain_text_content ); ?></textarea>
+							<?php endif; ?>
+						</div>
+
 						<button class="republish-article__copy-button" aria-label="<?php esc_attr_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>">
 							<?php esc_html_e( 'Copy to clipboard', 'republication-tracker-tool' ); ?>
 						</button>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change adds a tabbed interface for an additional section of "allowing plain text" to be copied by users from widget/republishable post. The plain text offers three fields:-
- Canonical URL tag.
- Post content.
- Attributions & tracking snippet.

<img width="521" height="528" alt="Screenshot 2025-08-13 at 12 02 46 PM" src="https://github.com/user-attachments/assets/7e1530af-1900-424a-8743-186aa38266dd" />

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210992220602515?focus=true .

### How to test the changes in this Pull Request:

1. Go to Settings > Enable plain text option.
2. View a republishable post or visit republishable template for a post( https://a8c.com/republish/POST_SLUG ).
3. Observe Tabs for HTML & Plain Text.
4. Click copy and validate the information required is available on all three fields.
