### PR TITLE
feat: Add licenses filters

### DIFF
--- a/docs/customizing-licenses.md
+++ b/docs/customizing-licenses.md
@@ -1,0 +1,59 @@
+# Customizing Licenses
+
+The Republication Tracker Tool provides filters that allow developers to programmatically add, remove, or modify the available licenses.
+
+## Adding Custom Licenses
+
+You can add custom licenses using the `republication_tracker_tool_licenses` filter:
+
+```php
+function add_custom_licenses( $licenses ) {
+    // Add a custom license
+    $licenses['my-custom-license'] = [
+        'label' => 'My Custom License',
+        'description' => 'My Custom License Description',
+        'url' => 'https://example.com/my-license',
+        'badge' => 'https://example.com/my-license-badge.png'
+    ];
+
+    return $licenses;
+}
+add_filter( 'republication_tracker_tool_licenses', 'add_custom_licenses' );
+```
+
+## Modifying Existing Licenses
+
+You can modify or remove existing licenses:
+
+```php
+function modify_licenses( $licenses ) {
+    // Remove a license
+    unset( $licenses['cc-zero-1.0'] );
+
+    // Modify an existing license
+    $licenses['cc-by-4.0']['description'] = 'Modified CC BY 4.0 description';
+
+    return $licenses;
+}
+add_filter( 'republication_tracker_tool_licenses', 'modify_licenses' );
+```
+
+## Changing the Default License
+
+You can change the default license using the `republication_tracker_tool_default_license` filter:
+
+```php
+function change_default_license( $default_license ) {
+    return 'cc-by-4.0'; // Change default to CC BY 4.0
+}
+add_filter( 'republication_tracker_tool_default_license', 'change_default_license' );
+```
+
+## License Array Structure
+
+Each license in the array should have the following structure:
+
+- **label** (string, required): Display label for the license
+- **description** (string, required): Full description of the license
+- **url** (string, required): URL to the license text
+- **badge** (string, optional): URL to the license badge image

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -245,9 +245,8 @@ class Republication_Tracker_Tool_Settings {
 	}
 
 	public function republication_tracker_tool_license_callback() {
-		$selected = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
-
-		$licenses = REPUBLICATION_TRACKER_TOOL_LICENSES;
+		$selected = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+		$licenses = republication_tracker_tool_get_licenses();
 
 		?>
 		<fieldset>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -160,7 +160,7 @@ class Republication_Tracker_Tool_Settings {
 				'teeny'         => true,
 			)
 		);
-		printf( '<p><em>%s</em></p>', wp_kses_post( __( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy hat uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.', 'republication-tracker-tool' ) ) );
+		printf( '<p><em>%s</em></p>', wp_kses_post( __( 'The Republication Tracker Tool Policy field is where you will be able to input your rules and policies for users to see before they copy and paste your content to republish.As an example of a republication policy that uses a Creative Commons license, check out the list in this plugin\'s <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/configuring-plugin-settings.md#republication-tracker-tool-policy" target="_blank">documentation</a> on GitHub.', 'republication-tracker-tool' ) ) );
 	}
 
 	public function republication_tracker_tool_analytics_id_callback() {

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -132,7 +132,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 	public function form( $instance ) {
 		echo sprintf( '<p><em>%s</em></p>', esc_html__( 'This widget will only display on single articles.', 'republication-tracker-tool' ) );
 		$title  = ! empty( $instance['title'] )  ? $instance['title'] : '';
-		$text   = ! empty( $instance['text'] )   ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under the terms of our license.', 'republication-tracker-tool' );
+		$text   = ! empty( $instance['text'] )   ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under a Creative Commons license.', 'republication-tracker-tool' );
 		$layout = ! empty( $instance['layout'] ) ? $instance['layout'] : 'modal'
 		?>
 		<p>

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -86,7 +86,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		echo sprintf(
 			'<p><a class="license" rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
 			isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['url'] : '',
-			esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
+			isset( $licenses[ $license_key ] ) ? esc_attr( $licenses[ $license_key ]['description'] ) : esc_html__( 'License', 'republication-tracker-tool' ),
 			esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/' . $license_key . '.png'
 		);
 
@@ -132,7 +132,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 	public function form( $instance ) {
 		echo sprintf( '<p><em>%s</em></p>', esc_html__( 'This widget will only display on single articles.', 'republication-tracker-tool' ) );
 		$title  = ! empty( $instance['title'] )  ? $instance['title'] : '';
-		$text   = ! empty( $instance['text'] )   ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under a Creative Commons license.', 'republication-tracker-tool' );
+		$text   = ! empty( $instance['text'] )   ? $instance['text'] : esc_html__( 'Republish our articles for free, online or in print, under the terms of our license.', 'republication-tracker-tool' );
 		$layout = ! empty( $instance['layout'] ) ? $instance['layout'] : 'modal'
 		?>
 		<p>

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -41,7 +41,8 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		global $post;
 
-		$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+		$license_key = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+		$licenses    = republication_tracker_tool_get_licenses();
 
 		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
 		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ), $post );
@@ -84,7 +85,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		echo sprintf(
 			'<p><a class="license" rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
-			REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+			isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['url'] : '',
 			esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
 			esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/' . $license_key . '.png'
 		);

--- a/includes/licenses.php
+++ b/includes/licenses.php
@@ -51,8 +51,6 @@ const REPUBLICATION_TRACKER_TOOL_LICENSES = [
  *
  * This function allows licenses to be filtered and modified programmatically.
  *
- * @since 1.0
- *
  * @return array Array of available licenses
  */
 function republication_tracker_tool_get_licenses() {
@@ -61,8 +59,6 @@ function republication_tracker_tool_get_licenses() {
 	 *
 	 * This filter allows users to add, remove, or modify the available licenses
 	 * that can be selected for republication tracking.
-	 *
-	 * @since 1.0
 	 *
 	 * @param array $licenses Array of available licenses. Each license should be an array with:
 	 *                       - 'label' (string): Display label for the license
@@ -78,8 +74,6 @@ function republication_tracker_tool_get_licenses() {
  *
  * This function allows the default license to be filtered and modified programmatically.
  *
- * @since 1.0
- *
  * @return string Default license key
  */
 function republication_tracker_tool_get_default_license() {
@@ -88,8 +82,6 @@ function republication_tracker_tool_get_default_license() {
 	 *
 	 * This filter allows users to change the default license that is selected
 	 * when the plugin is first installed or when no license has been chosen.
-	 *
-	 * @since 1.0
 	 *
 	 * @param string $default_license The default license key
 	 */

--- a/includes/licenses.php
+++ b/includes/licenses.php
@@ -45,3 +45,53 @@ const REPUBLICATION_TRACKER_TOOL_LICENSES = [
 		'badge' => 'https://licensebuttons.net/l/zero/1.0/88x31.png'
 	],
 ];
+
+/**
+ * Get the available republication tracker tool licenses.
+ *
+ * This function allows licenses to be filtered and modified programmatically.
+ *
+ * @since 1.0
+ *
+ * @return array Array of available licenses
+ */
+function republication_tracker_tool_get_licenses() {
+	/**
+	 * Filter the available republication tracker tool licenses.
+	 *
+	 * This filter allows users to add, remove, or modify the available licenses
+	 * that can be selected for republication tracking.
+	 *
+	 * @since 1.0
+	 *
+	 * @param array $licenses Array of available licenses. Each license should be an array with:
+	 *                       - 'label' (string): Display label for the license
+	 *                       - 'description' (string): Description of the license
+	 *                       - 'url' (string): URL to the license text
+	 *                       - 'badge' (string): URL to the license badge image (optional)
+	 */
+	return apply_filters( 'republication_tracker_tool_licenses', REPUBLICATION_TRACKER_TOOL_LICENSES );
+}
+
+/**
+ * Get the default license key for republication tracker tool.
+ *
+ * This function allows the default license to be filtered and modified programmatically.
+ *
+ * @since 1.0
+ *
+ * @return string Default license key
+ */
+function republication_tracker_tool_get_default_license() {
+	/**
+	 * Filter the default republication tracker tool license.
+	 *
+	 * This filter allows users to change the default license that is selected
+	 * when the plugin is first installed or when no license has been chosen.
+	 *
+	 * @since 1.0
+	 *
+	 * @param string $default_license The default license key
+	 */
+	return apply_filters( 'republication_tracker_tool_default_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+}

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -64,7 +64,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 	echo '<span class="screen-reader-text">' . esc_html( 'Close window', 'republication-tracker-tool' ) . '</span> <span aria-hidden="true">X</span></button>';
 	printf( '<h2 id="republish-modal-label">%s</h2>', esc_html__( 'Republish this article', 'republication-tracker-tool' ) );
 
-	// Explain Creative Commons
+	// Explain licensing
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
 			if ( isset( $licenses[ $license_key ] ) ) {
@@ -73,7 +73,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 			echo wp_kses_post(
 				wpautop(
 					sprintf(
-						// translators: %1$s is the URL to the particular Creative Commons license.
+						// translators: %1$s is the URL to the particular license, %2$s is the license description.
 						__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
 						isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['url'] : '',
 						isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['description'] : '',

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -56,7 +56,8 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  * @var HTML $license_statement
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
-$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+$license_key = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+$licenses    = republication_tracker_tool_get_licenses();
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
@@ -66,14 +67,16 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
 		echo '<div class="cc-license">';
-			printf( '<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>', REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'], REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'], REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge'] );
+			if ( isset( $licenses[ $license_key ] ) ) {
+				printf( '<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>', $licenses[ $license_key ]['url'], $licenses[ $license_key ]['description'], isset( $licenses[ $license_key ]['badge'] ) ? $licenses[ $license_key ]['badge'] : '' );
+			}
 			echo wp_kses_post(
 				wpautop(
 					sprintf(
 						// translators: %1$s is the URL to the particular Creative Commons license.
 						__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
-						REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-						REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+						isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['url'] : '',
+						isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['description'] : '',
 					)
 				)
 			);

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -56,8 +56,8 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
  * @var HTML $license_statement
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
-$license_key = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
-$licenses    = republication_tracker_tool_get_licenses();
+$license_key       = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+$licenses          = republication_tracker_tool_get_licenses();
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Republication Tracker Tool
- * Description:     Allow readers to share your content via a creative commons license.
+ * Description:     Allow readers to share your content under a license e.g. Creative Commons license
  * Author:          INN Labs
  * Author URI:      https://labs.inn.org
  * Text Domain:     republication-tracker-tool

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -286,9 +286,10 @@ final class Republication_Tracker_Tool {
 		$additional_tracking_code = self::create_additional_tracking_code_markup( $post->ID );
 		$tracking_html            = htmlentities( $pixel ) . htmlentities( $parsely_tracking ) . htmlentities( $additional_tracking_code );
 
-		$license_key         = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
-		$license_url         = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'];
-		$license_description = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'];
+		$license_key         = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+		$licenses            = republication_tracker_tool_get_licenses();
+		$license_url         = isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['url'] : '';
+		$license_description = isset( $licenses[ $license_key ] ) ? $licenses[ $license_key ]['description'] : '';
 
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 		if ( 'on' === $display_attribution && null !== $post ) {

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -173,7 +173,7 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 							echo wp_kses_post(
 								wpautop(
 									sprintf(
-									// translators: %1$s is the URL to the particular Creative Commons license.
+									// translators: %1$s is the URL to the particular license, %2$s is the license description.
 										__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
 										$licenses[ $license_key ]['url'],
 										$licenses[ $license_key ]['description'],

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -23,13 +23,17 @@ if ( ! $post_object instanceof WP_Post ) {
 $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
 $license_statement = get_option( 'republication_tracker_tool_policy' );
-$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
-$license_badge = sprintf(
-	'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge']
-);
+$license_key   = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+$licenses      = republication_tracker_tool_get_licenses();
+$license_badge = '';
+if ( isset( $licenses[ $license_key ] ) ) {
+	$license_badge = sprintf(
+		'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
+		$licenses[ $license_key ]['url'],
+		$licenses[ $license_key ]['description'],
+		isset( $licenses[ $license_key ]['badge'] ) ? $licenses[ $license_key ]['badge'] : ''
+	);
+}
 
 // Article title.
 $article_title = get_the_title( $republish_post_id );
@@ -165,16 +169,18 @@ $republish_content = apply_filters( 'republication_tracker_tool_republish_articl
 					<div class="cc-license">
 						<?php
 						echo $license_badge;
-						echo wp_kses_post(
-							wpautop(
-								sprintf(
-								// translators: %1$s is the URL to the particular Creative Commons license.
-									__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
-									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+						if ( isset( $licenses[ $license_key ] ) ) {
+							echo wp_kses_post(
+								wpautop(
+									sprintf(
+									// translators: %1$s is the URL to the particular Creative Commons license.
+										__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
+										$licenses[ $license_key ]['url'],
+										$licenses[ $license_key ]['description'],
+									)
 								)
-							)
-						);
+							);
+						}
 						?>
 					</div>
 				</div>

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -23,9 +23,9 @@ if ( ! $post_object instanceof WP_Post ) {
 $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_object->post_content, $republish_post_id );
 
 $license_statement = get_option( 'republication_tracker_tool_policy' );
-$license_key   = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
-$licenses      = republication_tracker_tool_get_licenses();
-$license_badge = '';
+$license_key       = get_option( 'republication_tracker_tool_license', republication_tracker_tool_get_default_license() );
+$licenses          = republication_tracker_tool_get_licenses();
+$license_badge     = '';
 if ( isset( $licenses[ $license_key ] ) ) {
 	$license_badge = sprintf(
 		'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPMIG-1403/republication-tracker-tool-allow-licenses-to-be-filtered.

This PR adds filter hooks to the Republication Tracker Tool plugin to allow new licenses to be added, modified, or removed programmatically.
Filters added:-
- `republication_tracker_tool_licenses` filter to modify available licenses
- `republication_tracker_tool_default_license` filter to change the default license

### How to test the changes in this Pull Request:

1. Add `republication_tracker_tool_licenses` filter:

```php
function add_custom_licenses( $licenses ) {
    // Add a custom license
    $licenses['my-custom-license'] = [
        'label' => 'My Custom License',
        'description' => 'My Custom License Description',
        'url' => 'https://example.com/my-license',
        'badge' => 'https://example.com/my-license-badge.png'
    ];

    return $licenses;
}
add_filter( 'republication_tracker_tool_licenses', 'add_custom_licenses' );
```
2. Open Admin > Settings > Reading.
3. Notice the new added License as an option.
4. For a fresh install, checkout the default license being used in admin.
5.  Add `republication_tracker_tool_default_license` filter:
```
function change_default_license( $default_license ) {
    return 'cc-by-sa-4.0'; // Change default to CC BY SA 4.0
}
add_filter( 'republication_tracker_tool_default_license', 'change_default_license' );
```
6. Check the default filter changed.

