### PR TITLE
feat: gracefully support no licenses

### DIFF
--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -171,14 +171,7 @@ class Republication_Tracker_Tool_Content {
 		// Add attribution.
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 		if ( 'on' === $display_attribution ) {
-			$license_key         = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
-			$license_description = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'];
-			$plain_text_content .= "\n" . sprintf(
-				// translators: %1$s is the site name, %2$s is the license description.
-				esc_html__( 'This article first appeared on %1$s and is republished here under a %2$s.', 'republication-tracker-tool' ),
-				get_bloginfo( 'name' ),
-				$license_description
-			) . "\n\n";
+			$plain_text_content .= Republication_Tracker_Tool::get_attribution( $post_object, true ) . "\n\n";
 		}
 
 		/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -268,7 +268,7 @@ class Republication_Tracker_Tool_Settings {
 							<?php endif; ?>
 							value="<?php esc_attr( $license_key ); ?>"
 						/>
-						<?php esc_html_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
+						<?php esc_html( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
 					</label>
 					<br>
 				<?php endforeach; ?>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -281,7 +281,7 @@ class Republication_Tracker_Tool_Settings {
 						<?php if ( 'none' === $selected ) : ?>
 							checked
 						<?php endif; ?>
-						value="<?php esc_attr_e( 'none' ); ?>"
+						value="none"
 					/>
 					<?php _e( 'No License', 'republication-tracker-tool' ); ?>
 				</label>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -283,7 +283,7 @@ class Republication_Tracker_Tool_Settings {
 						<?php endif; ?>
 						value="<?php esc_attr_e( 'none' ); ?>"
 					/>
-					<?php _e( 'No License' ); ?>
+					<?php _e( 'No License', 'republication-tracker-tool' ); ?>
 				</label>
 				<br>
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -266,7 +266,7 @@ class Republication_Tracker_Tool_Settings {
 							<?php if ( $license_key === $selected ) : ?>
 								checked
 							<?php endif; ?>
-							value="<?php esc_attr_e( $license_key ); ?>"
+							value="<?php esc_attr( $license_key ); ?>"
 						/>
 						<?php esc_html_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
 					</label>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -257,21 +257,37 @@ class Republication_Tracker_Tool_Settings {
 		?>
 		<fieldset>
 			<p>
-			<?php foreach ( $licenses as $license_key => $license_values ) : ?>
+				<?php foreach ( $licenses as $license_key => $license_values ) : ?>
+					<label>
+						<input
+							type="radio"
+							id="<?php echo esc_attr( 'republication_tracker_tool_license' ) . '_' . $license_key; ?>"
+							name="<?php echo esc_attr( 'republication_tracker_tool_license' ); ?>"
+							<?php if ( $license_key === $selected ) : ?>
+								checked
+							<?php endif; ?>
+							value="<?php esc_attr_e( $license_key ); ?>"
+						/>
+						<?php esc_html_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
+					</label>
+					<br>
+				<?php endforeach; ?>
+
 				<label>
 					<input
 						type="radio"
-						id="<?php echo esc_attr( 'republication_tracker_tool_license' ) . '_' . $license_key; ?>"
+						id="republication_tracker_tool_license_none"
 						name="<?php echo esc_attr( 'republication_tracker_tool_license' ); ?>"
-						<?php if ( $license_key === $selected ) : ?>
+						<?php if ( 'none' === $selected ) : ?>
 							checked
 						<?php endif; ?>
-						value="<?php esc_attr_e( $license_key ); ?>"
+						value="<?php esc_attr_e( 'none' ); ?>"
 					/>
-					<?php esc_html_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
+					<?php _e( 'No License' ); ?>
 				</label>
 				<br>
-			<?php endforeach; ?>
+
+
 			</p>
 		</fieldset>
 		<?php

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -43,6 +43,10 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		$license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
 
+		$using_license = isset( REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ] );
+
+		$license_statement = get_option( 'republication_tracker_tool_policy' );
+
 		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
 		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ), $post );
 
@@ -83,12 +87,16 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 			);
 		}
 
-		echo sprintf(
-			'<p><a class="license" rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
-			REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-			esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
-			esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/' . $license_key . '.png'
-		);
+		if ( $using_license ) {
+			echo sprintf(
+				'<p><a class="license" rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a></p>',
+				REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+				esc_html__( 'Creative Commons License', 'republication-tracker-tool' ),
+				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/' . $license_key . '.png'
+			);
+		}
+
+		echo "<div class=\"message\">$license_statement</div>";
 
 		echo '</div>';
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -66,6 +66,7 @@ if ( $plain_text_enabled ) {
  */
 $license_statement = wp_kses_post( get_option( 'republication_tracker_tool_policy' ) );
 $license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
+$using_license = isset( REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ] );
 
 echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 'style="display:none;"' ) . '>';
 	echo '<button ' . ( $is_amp ? 'on="tap:republication-tracker-tool-modal.close"' : '' ) . ' class="republication-tracker-tool-close">';
@@ -74,7 +75,8 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 
 	// Explain Creative Commons
 	echo '<div class="cc-policy">';
-		echo '<div class="cc-license">';
+	echo '<div class="cc-license">';
+		if ( $using_license ) {
 			printf( '<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>', REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'], REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'], REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge'] );
 			echo wp_kses_post(
 				wpautop(
@@ -86,9 +88,10 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 					)
 				)
 			);
-			echo '</div>'; // .cc-license
-			echo wp_kses_post( $license_statement );
-			echo '</div>'; // .cc-policy
+		}
+	echo '</div>'; // .cc-license
+	echo "<p>" . wp_kses_post( $license_statement ) . "</p>";
+	echo '</div>'; // .cc-policy
 
 			// what we display to the embedder
 			echo '<div class="article-info">';

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -276,7 +276,7 @@ final class Republication_Tracker_Tool {
 	}
 
 	/**
-	 * Get attribution text, which will be inserted at the end of the copyable content.
+	 * Get attribution text and tracking code to be added to the content footer
 	 *
 	 * @param $post The shared post.
 	 */
@@ -286,35 +286,94 @@ final class Republication_Tracker_Tool {
 		$additional_tracking_code = self::create_additional_tracking_code_markup( $post->ID );
 		$tracking_html            = htmlentities( $pixel ) . htmlentities( $parsely_tracking ) . htmlentities( $additional_tracking_code );
 
-		$license_key         = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
-		$license_url         = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'];
-		$license_description = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'];
-
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
+
+		$attribution = '';
+
 		if ( 'on' === $display_attribution && null !== $post ) {
-			$site_icon_markup = '';
-			$site_icon_url    = get_site_icon_url( 150 );
-			if ( ! empty( $site_icon_url ) ) {
-				$site_icon_markup = sprintf(
-					'<img src="%1$s" style="width:1em;height:1em;margin-left:10px;">',
-					esc_attr( $site_icon_url ),
+			$attribution = self::get_attribution( $post );
+		}
+
+		return $attribution . $tracking_html;
+	}
+
+	/**
+	 * Get attribution text and tracking code to be added to the content footer
+	 *
+	 * @param \WP_Post $post The shared post.
+	 * @param bool $plain_text Whether to return plain text.
+	 */
+	public static function get_attribution( \WP_Post $post, $plain_text = false ) {
+		$license_key         = get_option( 'republication_tracker_tool_license', 'cc-by-nd-4.0' );
+
+		$site_icon_markup = '';
+		$site_icon_url    = get_site_icon_url( 150 );
+		if ( ! empty( $site_icon_url ) ) {
+			$site_icon_markup = sprintf(
+				'<img src="%1$s" style="width:1em;height:1em;margin-left:10px;">',
+				esc_attr( $site_icon_url ),
+			);
+		}
+
+		if ( isset( REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ] ) ) {
+			$license_url         = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'];
+			$license_description = REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'];
+
+			if ( $plain_text ) {
+				$attribution = sprintf(
+					// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
+					esc_html__( 'This article first appeared on %1$s and is republished here under a %2$s.', 'republication-tracker-tool' ),
+					esc_html( get_bloginfo() ),
+					$license_description
+				);
+			} else {
+				$attribution = wpautop(
+					sprintf(
+						// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
+						esc_html__( 'This <a target="_blank" href="%1$s">article</a> first appeared on <a target="_blank" href="%2$s">%3$s</a> and is republished here under a <a target="_blank" href="%4$s">%5$s</a>.', 'republication-tracker-tool' ),
+						get_permalink( $post ),
+						home_url(),
+						esc_html( get_bloginfo() ),
+						$license_url,
+						$license_description
+					) . htmlentities( $site_icon_markup )
 				);
 			}
 
-			return wpautop(
-				sprintf(
-				// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
-					esc_html__( 'This <a target="_blank" href="%1$s">article</a> first appeared on <a target="_blank" href="%2$s">%3$s</a> and is republished here under a <a target="_blank" href="%4$s">%5$s</a>.', 'republication-tracker-tool' ),
-					get_permalink( $post ),
-					home_url(),
-					esc_html( get_bloginfo() ),
-					$license_url,
-					$license_description
-				) . htmlentities( $site_icon_markup ) . $tracking_html
-			);
+
+		} else {
+
+			if ( $plain_text ) {
+				$attribution = sprintf(
+					// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
+					esc_html__( 'This article first appeared on %1$s.', 'republication-tracker-tool' ),
+					esc_html( get_bloginfo() )
+				);
+			} else {
+
+				$attribution = wpautop(
+					sprintf(
+						// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title.
+						esc_html__( 'This <a target="_blank" href="%1$s">article</a> first appeared on <a target="_blank" href="%2$s">%3$s</a>.', 'republication-tracker-tool' ),
+						get_permalink( $post ),
+						home_url(),
+						esc_html( get_bloginfo() ),
+					) . htmlentities( $site_icon_markup )
+				);
+			}
 		}
-		return $tracking_html;
+
+		/**
+		 * Filters the attribution HTML for the given post.
+		 *
+		 * @param string $attribution The attribution HTML.
+		 * @param \WP_Post $post The post object.
+		 * @param bool $plain_text Whether the attribution is plain text.
+		 */
+		return apply_filters( 'republication_tracker_tool_attribution', $attribution, $post, $plain_text );
+
 	}
+
 }
 
 /**

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -321,7 +321,7 @@ final class Republication_Tracker_Tool {
 
 			if ( $plain_text ) {
 				$attribution = sprintf(
-					// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
+					// translators: %1$s is the site title, %2$s is the license description.
 					esc_html__( 'This article first appeared on %1$s and is republished here under a %2$s.', 'republication-tracker-tool' ),
 					esc_html( get_bloginfo() ),
 					$license_description

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -345,8 +345,8 @@ final class Republication_Tracker_Tool {
 
 			if ( $plain_text ) {
 				$attribution = sprintf(
-					// translators: %1$s is a URL, %2$s is the site home URL, %3$s is the site title. %4$s is the license URL, %5$s is the license description.
-					esc_html__( 'This article first appeared on %1$s.', 'republication-tracker-tool' ),
+					// translators: %s is the site title.
+					esc_html__( 'This article first appeared on %s.', 'republication-tracker-tool' ),
 					esc_html( get_bloginfo() )
 				);
 			} else {

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -189,7 +189,7 @@ if ( $plain_text_enabled ) {
 							echo wp_kses_post(
 								wpautop(
 									sprintf(
-									// translators: %1$s is the URL to the particular Creative Commons license.
+									// translators: %1$s is the URL to the particular Creative Commons license, %2$s is the license description.
 										__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
 										REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
 										REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],

--- a/templates/republish-template.php
+++ b/templates/republish-template.php
@@ -24,12 +24,17 @@ $content = Republication_Tracker_Tool_Content::get_republishable_content( $post_
 
 $license_statement = get_option( 'republication_tracker_tool_policy' );
 $license_key = get_option( 'republication_tracker_tool_license', REPUBLICATION_TRACKER_TOOL_DEFAULT_LICENSE );
-$license_badge = sprintf(
-	'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
-	REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge']
-);
+
+$using_license = isset( REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ] );
+
+if ( $using_license ) {
+	$license_badge = sprintf(
+		'<a rel="noreferrer license" target="_blank" href="%s"><img alt="%s" style="border-width:0" src="%s" /></a>',
+		REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+		REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+		REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['badge']
+	);
+}
 
 // Article title.
 $article_title = get_the_title( $republish_post_id );
@@ -177,21 +182,23 @@ if ( $plain_text_enabled ) {
 				<?php do_action( 'republication_tracker_tool_before_republish_content', $post_object ); ?>
 
 				<div class="cc-policy">
-					<div class="cc-license">
-						<?php
-						echo $license_badge;
-						echo wp_kses_post(
-							wpautop(
-								sprintf(
-								// translators: %1$s is the URL to the particular Creative Commons license.
-									__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
-									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
-									REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+					<?php if ( $using_license ) : ?>
+						<div class="cc-license">
+							<?php
+							echo $license_badge;
+							echo wp_kses_post(
+								wpautop(
+									sprintf(
+									// translators: %1$s is the URL to the particular Creative Commons license.
+										__( 'This work is licensed under a <a rel="noreferrer license" target="_blank" href="%1$s">%2$s</a>.', 'republication-tracker-tool' ),
+										REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['url'],
+										REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ]['description'],
+									)
 								)
-							)
-						);
-						?>
-					</div>
+							);
+							?>
+						</div>
+					<?php endif; ?>
 				</div>
 				<?php if ( ! empty( $license_statement ) ) : ?>
 					<section class="republish-article__license">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Adds an option to configure the plugin without a CC license and act accordingly
* Make the License statement visible in the Widget
* Add a filter to the attribution string

### How to test the changes in this Pull Request:

1. Go to Settings > Reading and choose the new "No license" option
2. Confirm all looks good in the widget, in the republication modal and in the republication page. There should be no reference to any license
3. Confirm that the attribution added to the end of the post content also does not have any reference to any license, both in the HTML and in the plain text versions
4. Add a Policy text to the settings and confirm it renders well in the three places
5. Add a license and confirm things work as usual
