### PR TITLE
HOTFIX: Missing labels in settings

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -266,9 +266,9 @@ class Republication_Tracker_Tool_Settings {
 							<?php if ( $license_key === $selected ) : ?>
 								checked
 							<?php endif; ?>
-							value="<?php esc_attr_e( $license_key ); ?>"
+							value="<?php echo esc_attr( $license_key ); ?>"
 						/>
-						<?php esc_attr_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
+						<?php echo esc_html( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
 					</label>
 					<br>
 				<?php endforeach; ?>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -266,9 +266,9 @@ class Republication_Tracker_Tool_Settings {
 							<?php if ( $license_key === $selected ) : ?>
 								checked
 							<?php endif; ?>
-							value="<?php esc_attr( $license_key ); ?>"
+							value="<?php esc_attr_e( $license_key ); ?>"
 						/>
-						<?php esc_html( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
+						<?php esc_attr_e( $license_values['label'] . ' - ' . $license_values['description'] ); ?>
 					</label>
 					<br>
 				<?php endforeach; ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the empty values displayed in settings.

### How to test the changes in this Pull Request:

1. Go to settings > reading on main branch.
2. Notice Licenses options missing labels.
3. Switch to this branch and check the labels.
