### PR TITLE
fix: remove license statement from widget

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -45,8 +45,6 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		$using_license = isset( REPUBLICATION_TRACKER_TOOL_LICENSES[ $license_key ] );
 
-		$license_statement = get_option( 'republication_tracker_tool_policy' );
-
 		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
 		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ), $post );
 
@@ -95,8 +93,6 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 				esc_url( plugin_dir_url( dirname( __FILE__ ) ) ) . 'assets/img/' . $license_key . '.png'
 			);
 		}
-
-		echo "<div class=\"message\">$license_statement</div>";
 
 		echo '</div>';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The license statement was added to the widget in https://github.com/Automattic/republication-tracker-tool/pull/270 but there's a reason it was not there. In some cases, this can be a lengthy statement and it's not meant to be displayed there, only on the page and in the republish modal
