### PR TITLE
fix: add tracking snippets to the plain text share screen

### DIFF
--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -57,6 +57,8 @@ if ( $plain_text_enabled ) {
 	$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
 	$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
 	$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
+	$pixel                    = Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID );
+	$parsely_tracking         = Republication_Tracker_Tool::create_parsely_tracking( $post->ID );
 }
 
 /**
@@ -159,15 +161,15 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 
 							<div class="plain-text-field">
 								<label class="plain-text-field__label" for="republication-tracker-tool-tracking-snippet">
-									<strong><?php esc_html_e( 'Attribution & Tracking:', 'republication-tracker-tool' ); ?></strong>
+									<strong><?php esc_html_e( 'Tracking snippet:', 'republication-tracker-tool' ); ?></strong>
 								</label>
 								<input
 									type="text"
 									id="republication-tracker-tool-tracking-snippet"
 									class="plain-text-field__input"
 									readonly
-									aria-label="<?php esc_attr_e( 'Attribution and tracking snippet', 'republication-tracker-tool' ); ?>"
-									value="<?php echo esc_html( $additional_tracking_html ); ?>"
+									aria-label="<?php esc_attr_e( 'Tracking snippet', 'republication-tracker-tool' ); ?>"
+									value="<?php echo esc_html( $pixel . $parsely_tracking . $additional_tracking_html ); ?>"
 								/>
 								<button class="plain-text-field__button" data-target="#republication-tracker-tool-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
 									<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As of now, only the "additional tracking snippet" is being added to the field in the plain text share screen. This PR adds all the tracking code there

### How to test the changes in this Pull Request:

1. Set a share widget
2. Click share and go to plain text
3. Confirm the Tracking snippet input has both the tracking pixel and the additional snippet

