### PR TITLE
feat: filters to allow overriding tracking code

### DIFF
--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -54,11 +54,19 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
 $plain_text_content = '';
 if ( $plain_text_enabled ) {
-	$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
-	$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
-	$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
-	$pixel                    = Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID );
-	$parsely_tracking         = Republication_Tracker_Tool::create_parsely_tracking( $post->ID );
+		$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
+		$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
+		$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
+		$pixel                    = Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID );
+		$parsely_tracking         = Republication_Tracker_Tool::create_parsely_tracking( $post->ID );
+
+		/**
+		 * Filters the tracking code for the plain text snippet.
+		 *
+		 * @param string $plain_text_tracking_snippet The tracking code for the plain text snippet.
+		 * @param WP_Post $post The post object.
+		 */
+		$plain_text_tracking_snippet = apply_filters( 'republication_tracker_tool_text_tracking_code', $pixel . $parsely_tracking . $additional_tracking_html, $post );
 }
 
 /**
@@ -169,7 +177,7 @@ echo '<div id="republication-tracker-tool-modal-content" ' . ( $is_amp ? '' : 's
 									class="plain-text-field__input"
 									readonly
 									aria-label="<?php esc_attr_e( 'Tracking snippet', 'republication-tracker-tool' ); ?>"
-									value="<?php echo esc_html( $pixel . $parsely_tracking . $additional_tracking_html ); ?>"
+									value="<?php echo esc_html( $plain_text_tracking_snippet ); ?>"
 								/>
 								<button class="plain-text-field__button" data-target="#republication-tracker-tool-tracking-snippet" aria-label="<?php esc_attr_e( 'Copy tracking snippet', 'republication-tracker-tool' ); ?>">
 									<?php esc_html_e( 'Copy Snippet', 'republication-tracker-tool' ); ?>

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -54,19 +54,19 @@ $article_info = str_replace( '<p></p>', '', wpautop( $article_info ) );
 $plain_text_enabled = Republication_Tracker_Tool_Settings::is_plain_text_enabled();
 $plain_text_content = '';
 if ( $plain_text_enabled ) {
-		$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
-		$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
-		$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
-		$pixel                    = Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID );
-		$parsely_tracking         = Republication_Tracker_Tool::create_parsely_tracking( $post->ID );
+	$canonical_tag            = sprintf( '<link rel="canonical" href="%s" />', esc_url( get_permalink( $post->ID ) ) );
+	$plain_text_content       = Republication_Tracker_Tool_Content::get_republishable_plain_text_content( $post );
+	$additional_tracking_html = Republication_Tracker_Tool::create_additional_tracking_code_markup( $post->ID );
+	$pixel                    = Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID );
+	$parsely_tracking         = Republication_Tracker_Tool::create_parsely_tracking( $post->ID );
 
-		/**
-		 * Filters the tracking code for the plain text snippet.
-		 *
-		 * @param string $plain_text_tracking_snippet The tracking code for the plain text snippet.
-		 * @param WP_Post $post The post object.
-		 */
-		$plain_text_tracking_snippet = apply_filters( 'republication_tracker_tool_text_tracking_code', $pixel . $parsely_tracking . $additional_tracking_html, $post );
+	/**
+	 * Filters the tracking code for the plain text snippet.
+	 *
+	 * @param string $plain_text_tracking_snippet The tracking code for the plain text snippet.
+	 * @param WP_Post $post The post object.
+	 */
+	$plain_text_tracking_snippet = apply_filters( 'republication_tracker_tool_text_tracking_code', $pixel . $parsely_tracking . $additional_tracking_html, $post );
 }
 
 /**

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -286,6 +286,14 @@ final class Republication_Tracker_Tool {
 		$additional_tracking_code = self::create_additional_tracking_code_markup( $post->ID );
 		$tracking_html            = htmlentities( $pixel ) . htmlentities( $parsely_tracking ) . htmlentities( $additional_tracking_code );
 
+		/**
+		 * Filters the tracking code HTML for the given post.
+		 *
+		 * @param string $tracking_html The tracking HTML.
+		 * @param \WP_Post $post The post object.
+		 */
+		$tracking_html = apply_filters( 'republication_tracker_tool_tracking_code', $tracking_html, $post );
+
 		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
 
 		$attribution = '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPMIG-1710/rtt-add-a-filter-for-the-tracking-code.

Adds new filters that allow devs to override/modify the tracking code output before it is added to the normal republish widget content and the plain text tracking snippet.
1. `republication_tracker_tool_tracking_code` (Markup)
2. `republication_tracker_tool_text_tracking_code` (Plain text)

### How to test the changes in this Pull Request:

1. Hook into both filters (`republication_tracker_tool_tracking_code` and `republication_tracker_tool_text_tracking_code`) and change their output (e.g., append <!-- test -->). Example:-
```
<?php
add_filter( 'republication_tracker_tool_tracking_code', function( $tracking_code, $post ) {
	return '<!-- TEST OVERRIDE -->' . "\n" . $tracking_code . "\n" . '<!-- END TEST -->';
}, 10, 2 );

add_filter( 'republication_tracker_tool_text_tracking_code', function( $plain_text_tracking_snippet, $post ) {
	return "\n" . '<!-- TEST OVERRIDE - PLAIN -->' . "\n" . $plain_text_tracking_snippet . "\n" . '<!-- END TEST - PLAIN -->' . "\n";
}, 10, 2 );
```
2. Open a post with the Republish modal.
3. Check the HTML modal tracking code and verify the override appears.
4. Ensure the plain text tracking code also reflects the override.
