### PR TITLE
fix: Remove scripts and styles

### DIFF
--- a/includes/class-content.php
+++ b/includes/class-content.php
@@ -30,6 +30,9 @@ class Republication_Tracker_Tool_Content {
 		// Remove comments from the content. (Lookin' at you, Gutenberg.)
 		$content = preg_replace( '/<!--(.|\s)*?-->/i', ' ', $content );
 
+		// Remove scripts from the content.
+		$content = preg_replace( '@<script\b[^>]*?>.*?</script>@si', '', $content );
+
 		/**
 		 * What tags do we want to keep in the embed?
 		 * Not things from our server.
@@ -201,6 +204,7 @@ class Republication_Tracker_Tool_Content {
 		$html_content = preg_replace( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/is', "\n$1\n\n", $html_content );
 		$html_content = preg_replace( '/<p[^>]*>(.*?)<\/p>/is', "$1\n\n", $html_content );
 		$html_content = preg_replace( '/<br\s*\/?>/i', "\n", $html_content );
+		$html_content = preg_replace( '/<style\b[^>]*?>.*?<\/style>/si', '', $html_content );
 
 		// ul to bullet points
 		$html_content = preg_replace_callback(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPMIG-1709/rtt-remove-javascript-code-from-text-only-version .

This PR adds code to remove <script> and <style> tags along with their content before wp_kses processing.

The issue occurred because wp_kses strips HTML tags but leaves their content, causing JavaScript code and CSS to appear as plain text in the republished content. This fix removes the tags and their content entirely before the wp_kses filtering step.

### How to test the changes in this Pull Request:

1. Create a test post with embedded <script> tags containing JavaScript code and <style> tags with CSS.
2. Open the Republication Tracker Tool modal for that post.
3. Verify that the JavaScript code and CSS styles do not appear in either the HTML textarea or the plain text version.
4. Test the same with republish template as well.
