### PR TITLE
fix: bump newspack-scripts version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"grunt": "~1.6.1",
 				"grunt-wp-i18n": "~1.0.3",
 				"grunt-wp-readme-to-markdown": "~2.1.0",
-				"newspack-scripts": "^5.9.0"
+				"newspack-scripts": "^5.9.5"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -22339,9 +22339,9 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.9.0",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.9.0.tgz",
-			"integrity": "sha512-yhctm7ilx6JWxpn8tYGEqDyvG1DrUq+SkWWM10q44e6+Dr6PRfTAYzWCMYBMp5sbIA7E0C92i6//Y6gRDA8xWg==",
+			"version": "5.9.5",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.9.5.tgz",
+			"integrity": "sha512-GtM1x8FiW5HvaW1iJEPBq4x+kmPl19ap+BPFmCMgTdihjny/kdiUnQuM+Lm5hGwbuy3eCihYSHwGPst9m1rTKg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
 		"grunt": "~1.6.1",
 		"grunt-wp-i18n": "~1.0.3",
 		"grunt-wp-readme-to-markdown": "~2.1.0",
-		"newspack-scripts": "^5.9.0"
+		"newspack-scripts": "^5.9.5"
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like the release job is failing with a newspack-scripts error:

```
node:internal/modules/cjs/loader:1459
  throw err;
  ^

Error: Cannot find module './utils/index.js'
Require stack:
- /home/runner/work/republication-tracker-tool/republication-tracker-tool/node_modules/newspack-scripts/scripts/github/release.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1456:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1066:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1071:22)
    at Module._load (node:internal/modules/cjs/loader:1242:25)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1556:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/home/runner/work/republication-tracker-tool/republication-tracker-tool/node_modules/newspack-scripts/scripts/github/release.js:3:15)
    at Module._compile (node:internal/modules/cjs/loader:1812:14)
    at Object..js (node:internal/modules/cjs/loader:1943:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/republication-tracker-tool/republication-tracker-tool/node_modules/newspack-scripts/scripts/github/release.js'
  ]
}

Node.js v24.14.0
Error: Process completed with exit code 1.
```

This PR bumps the version to hopefully resolve this.

### How to test the changes in this Pull Request:

Confirm all tests pass.