### PR TITLE
fix(pixel): serve gif regardless of ga4 query param

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -74,7 +74,10 @@ function wprtt_extract_cid_from_cookies() {
 	return wprtt_create_cid_cookie_if_not_set();
 }
 
-if ( isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+// Non-ga4 hits (bots, crawlers) skip this block entirely. No counter update, no DB writes.
+// The wp-admin referrer bailout below is therefore only needed within this block.
+// Only update share tracking when a ga4 param is present (real pixel fires from configured republishers).
+if ( isset( $_GET['post'] ) && isset( $_GET['ga4'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	// set up all of our post vars we want to track.
 	$shared_post_id = absint( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -162,7 +162,8 @@ final class Republication_Tracker_Tool {
 			function( $template ) {
 				// If the params are set, use our pixel functions.
 				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					return include_once plugin_dir_path( __FILE__ ) . 'includes/pixel.php';
+					include_once plugin_dir_path( __FILE__ ) . 'includes/pixel.php';
+					exit;
 					// Else, continue with whatever template was being loaded.
 				} else {
 					return $template;

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -161,7 +161,7 @@ final class Republication_Tracker_Tool {
 			'template_include',
 			function( $template ) {
 				// If the params are set, use our pixel functions.
-				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && isset( $_GET['ga4'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				if ( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					return include_once plugin_dir_path( __FILE__ ) . 'includes/pixel.php';
 					// Else, continue with whatever template was being loaded.
 				} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Republication Tracker Tool's `template_include` filter required `ga4` to be present before serving the pixel gif. Requests without `ga4`, including all crawler and scraper traffic, fell through to the normal WordPress template, returning a full HTML page. Google indexed these as duplicates, producing 6.19M "Duplicate without user-selected canonical" URLs in Google Search Console.

This fix removes `ga4` from the outer gate so the pixel gif is always served for `?republication-pixel=true&post=N` requests. Share-counter tracking is preserved: the `update_post_meta` call inside `pixel.php` retains its `ga4` requirement, so only real pixel fires from configured republishers increment the count. Non-ga4 hits (bots, crawlers) skip the tracking block entirely.  No counter update, no DB writes.

Closes NPPM-2737.

### How to test the changes in this Pull Request:

**Reproduce the problem** (on `trunk`, before the fix):
1. Open Chrome DevTools → **Network** tab → enable **Preserve log** and **Disable cache**.
2. Navigate to `/?republication-pixel=true&post=<id>` (no `ga4`).
3. Click the top (document) request → **Headers** tab → confirm `Content-Type: text/html`.
4. Additionally, you can do the following and will see: `200 text/html` (the problem)
```
curl -s -o /dev/null -w "%{http_code} %{content_type}\n" "https://<site>/?republication-pixel=true&post=<id>"
```

**Verify the fix** (on this branch):
1. Return to the same page (shift + reload)
2. Click the top (document) request → **Headers** tab → confirm `Content-Type: image/png`.
3. Additionally, you can do the following and will see `200 image/png`.
```
curl -s -o /dev/null -w "%{http_code} %{content_type}\n" "https://<site>/?republication-pixel=true&post=<id>"
curl -s -o /dev/null -w "%{http_code} %{content_type}\n" "https://<site>/?republication-pixel=true&post=<id>&ga4=test"
```

| URL | Before | After |
|-----|--------|-------|
| `?republication-pixel=true&post=<id>` | 200 text/html | 200 image/png |
| `?republication-pixel=true&post=<id>&ga4=test` | 200 image/png | 200 image/png |

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
