### PR TITLE
fix: make hide-widget meta box compatible with RTC

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -35,3 +35,4 @@ contributing.md
 docs
 release.sh
 release
+src

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
+dist/
 release/
 vendor
 .phpunit.result.cache

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -281,7 +281,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post );
 
 		if ( true == $hide_republication_widget_by_filter ) {
-			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
+			echo '<p>The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
 		} else {
 
 			echo '<label>';

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -93,6 +93,35 @@ class Republication_Tracker_Tool_Article_Settings {
 					),
 				)
 			);
+			register_rest_field(
+				$post_type,
+				'republication_tracker_tool_share_data',
+				array(
+					'get_callback' => function( $post_array ) {
+						$shares = get_post_meta( $post_array['id'], 'republication_tracker_tool_sharing', true );
+						if ( ! is_array( $shares ) ) {
+							$shares = array();
+						}
+						$total   = 0;
+						$entries = array();
+						foreach ( $shares as $url => $count ) {
+							$total    += (int) $count;
+							$entries[] = array(
+								'url'   => (string) $url,
+								'count' => (int) $count,
+							);
+						}
+						return array(
+							'total'   => $total,
+							'entries' => $entries,
+						);
+					},
+					'schema'       => array(
+						'type'    => 'object',
+						'context' => array( 'edit' ),
+					),
+				)
+			);
 		}
 	}
 

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -38,7 +38,10 @@ class Republication_Tracker_Tool_Article_Settings {
 	 * @since  1.0
 	 */
 	public function hooks() {
+		add_action( 'init', array( $this, 'register_meta' ) );
+		add_action( 'rest_api_init', array( $this, 'register_rest_fields' ) );
 		add_action( 'add_meta_boxes', array( $this, 'register_meta_boxes' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 		add_action( 'manage_edit-post_columns', array( $this, 'add_custom_columns' ) );
 		add_action( 'manage_edit-post_sortable_columns', array( $this, 'add_sortable_columns' ) );
 		add_action( 'manage_posts_custom_column', array( $this, 'custom_column_content' ), 10, 2 );
@@ -46,19 +49,72 @@ class Republication_Tracker_Tool_Article_Settings {
 		add_action( 'wp_insert_post', array( $this, 'apply_default_post_distribution' ), 10, 3 );
 	}
 
+	/**
+	 * Register the hide-widget meta so the block editor can read/write it via REST.
+	 *
+	 * @since 2.8.3
+	 */
+	public function register_meta() {
+		foreach ( array( 'post' ) as $post_type ) {
+			register_post_meta(
+				$post_type,
+				'republication-tracker-tool-hide-widget',
+				array(
+					'show_in_rest'  => true,
+					'single'        => true,
+					'type'          => 'boolean',
+					'auth_callback' => function() {
+						return current_user_can( 'edit_posts' );
+					},
+				)
+			);
+		}
+	}
 
 	/**
-	 * Add custom metaboxes.
+	 * Expose whether the hide_republication_widget filter forces hiding,
+	 * so the block editor sidebar can render a notice instead of the toggle.
+	 *
+	 * @since 2.8.3
+	 */
+	public function register_rest_fields() {
+		foreach ( array( 'post' ) as $post_type ) {
+			register_rest_field(
+				$post_type,
+				'republication_tracker_tool_filter_hides',
+				array(
+					'get_callback' => function( $post_array ) {
+						$post = get_post( $post_array['id'] );
+						return (bool) apply_filters( 'hide_republication_widget', false, $post );
+					},
+					'schema'       => array(
+						'type'    => 'boolean',
+						'context' => array( 'edit' ),
+					),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Add custom metaboxes for the Classic Editor only.
+	 *
+	 * In the block editor the sidebar panel registered in src/index.js handles this UI,
+	 * and registering classic meta boxes here would block real-time collaboration.
 	 *
 	 * @since 1.0
 	 */
 	public function register_meta_boxes() {
+		$screen = get_current_screen();
+		if ( $screen && method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() ) {
+			return;
+		}
 
 		add_meta_box(
 			'republication-tracker-tool',
 			esc_html__( 'Republication Tracker Tool', 'republication-tracker-tool' ),
 			array( $this, 'render_metabox' ),
-			array( 'post', 'page' ),
+			array( 'post' ),
 			'advanced',
 			'default'
 		);
@@ -67,12 +123,41 @@ class Republication_Tracker_Tool_Article_Settings {
 			'republication-tracker-tool-hide-widget',
 			esc_html__( 'Hide Republication Widget', 'republication-tracker-tool' ),
 			array( $this, 'render_hide_widget_metabox' ),
-			array( 'post', 'page' ),
+			array( 'post' ),
 			'side',
-			'default',
-			array(
-				'__block_editor_compatible_meta_box' => true,
-			)
+			'default'
+		);
+	}
+
+	/**
+	 * Enqueue the block editor sidebar panel.
+	 *
+	 * @since 2.8.3
+	 */
+	public function enqueue_editor_assets() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'post' !== $screen->post_type ) {
+			return;
+		}
+
+		$asset_file = REPUBLICATION_TRACKER_TOOL_PATH . 'dist/index.asset.php';
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+
+		$asset = include $asset_file;
+
+		wp_enqueue_script(
+			'republication-tracker-tool-editor',
+			REPUBLICATION_TRACKER_TOOL_URL . 'dist/index.js',
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+
+		wp_set_script_translations(
+			'republication-tracker-tool-editor',
+			'republication-tracker-tool'
 		);
 	}
 

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -52,7 +52,7 @@ class Republication_Tracker_Tool_Article_Settings {
 	/**
 	 * Register the hide-widget meta so the block editor can read/write it via REST.
 	 *
-	 * @since 2.8.3
+	 * @since 2.9.0
 	 */
 	public function register_meta() {
 		foreach ( array( 'post' ) as $post_type ) {
@@ -63,8 +63,8 @@ class Republication_Tracker_Tool_Article_Settings {
 					'show_in_rest'  => true,
 					'single'        => true,
 					'type'          => 'boolean',
-					'auth_callback' => function() {
-						return current_user_can( 'edit_posts' );
+					'auth_callback' => function( $allowed, $meta_key, $post_id, $user_id ) {
+						return user_can( $user_id, 'edit_post', $post_id );
 					},
 				)
 			);
@@ -75,7 +75,7 @@ class Republication_Tracker_Tool_Article_Settings {
 	 * Expose whether the hide_republication_widget filter forces hiding,
 	 * so the block editor sidebar can render a notice instead of the toggle.
 	 *
-	 * @since 2.8.3
+	 * @since 2.9.0
 	 */
 	public function register_rest_fields() {
 		foreach ( array( 'post' ) as $post_type ) {
@@ -161,7 +161,7 @@ class Republication_Tracker_Tool_Article_Settings {
 	/**
 	 * Enqueue the block editor sidebar panel.
 	 *
-	 * @since 2.8.3
+	 * @since 2.9.0
 	 */
 	public function enqueue_editor_assets() {
 		$screen = get_current_screen();
@@ -281,7 +281,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		$hide_republication_widget_by_filter = apply_filters( 'hide_republication_widget', $hide_republication_widget_by_filter, $post );
 
 		if ( true == $hide_republication_widget_by_filter ) {
-			echo '<p>The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
+			echo '<p>The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md" target="_blank" rel="noopener noreferrer">Read more about this filter</a>.</p>';
 		} else {
 
 			echo '<label>';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "2.8.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"grunt": "~1.6.1",
 				"grunt-wp-i18n": "~1.0.3",
 				"grunt-wp-readme-to-markdown": "~2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "2.8.2",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
+				"@typescript-eslint/eslint-plugin": "^6.21.0",
 				"grunt": "~1.6.1",
 				"grunt-wp-i18n": "~1.0.3",
 				"grunt-wp-readme-to-markdown": "~2.1.0",
@@ -7318,29 +7319,397 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.2",
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2",
-				"debug": "^4.3.4"
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/type-utils": "6.21.0",
+				"@typescript-eslint/utils": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "6.21.0",
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/typescript-estree": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"@typescript-eslint/visitor-keys": "6.21.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
+				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "6.21.0",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
@@ -8570,193 +8939,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-			"integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/type-utils": "6.21.0",
-				"@typescript-eslint/utils": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"graphemer": "^1.4.0",
-				"ignore": "^5.2.4",
-				"natural-compare": "^1.4.0",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-				"eslint": "^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/parser": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-			"integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -8931,22 +9113,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -8958,19 +9124,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/ts-api-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/yaml": {
@@ -22511,6 +22664,174 @@
 				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+			"integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/typescript-estree": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+			"integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.59.2",
+				"@typescript-eslint/tsconfig-utils": "8.59.2",
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+			"integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.59.2",
+				"@typescript-eslint/types": "^8.59.2",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+			"integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/parser/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+			"integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.2",
+				"@typescript-eslint/visitor-keys": "8.59.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/types": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+			"integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.59.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+			"integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.2",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/newspack-scripts/node_modules/@wordpress/block-editor": {
 			"version": "15.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.7.0.tgz",
@@ -23544,6 +23865,58 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/newspack-scripts/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"cm": "newspack-scripts commit",
 		"build": "newspack-scripts wp-scripts build",
 		"i18n": "grunt i18n",
-		"lint:js": "newspack-scripts wp-scripts lint-js",
+		"lint:js": "newspack-scripts wp-scripts lint-js src",
 		"readme": "grunt readme",
 		"semantic-release": "newspack-scripts release --files=republication-tracker-tool.php",
 		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/republication-tracker-tool --exclude-from='./.distignore' && cd release && zip -r republication-tracker-tool.zip republication-tracker-tool",
@@ -23,6 +23,7 @@
 		"url": "https://github.com/Automattic/republication-tracker-tool/issues"
 	},
 	"devDependencies": {
+		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"grunt": "~1.6.1",
 		"grunt-wp-i18n": "~1.0.3",
 		"grunt-wp-readme-to-markdown": "~2.1.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 	"scripts": {
 		"start": "npm ci",
 		"cm": "newspack-scripts commit",
-		"build": "echo 'No build in this repository.'",
+		"build": "newspack-scripts wp-scripts build",
 		"i18n": "grunt i18n",
-		"lint:js": "echo 'No JS to lint in this repository.'",
+		"lint:js": "newspack-scripts wp-scripts lint-js",
 		"readme": "grunt readme",
 		"semantic-release": "newspack-scripts release --files=republication-tracker-tool.php",
 		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/republication-tracker-tool --exclude-from='./.distignore' && cd release && zip -r republication-tracker-tool.zip republication-tracker-tool",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"url": "https://github.com/Automattic/republication-tracker-tool/issues"
 	},
 	"devDependencies": {
-		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"grunt": "~1.6.1",
 		"grunt-wp-i18n": "~1.0.3",
 		"grunt-wp-readme-to-markdown": "~2.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ const RepublicationTrackerPanel = () => {
 					filterHides
 						? createInterpolateElement(
 								__(
-									'The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',
+									'The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',
 									'republication-tracker-tool'
 								),
 								{

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,79 @@
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { ToggleControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+const META_KEY = 'republication-tracker-tool-hide-widget';
+
+const RepublicationTrackerPanel = () => {
+	const postType = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPostType(),
+		[]
+	);
+
+	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
+
+	const filterHides = useSelect(
+		( select ) =>
+			select( 'core/editor' ).getEditedPostAttribute(
+				'republication_tracker_tool_filter_hides'
+			),
+		[]
+	);
+
+	if ( 'post' !== postType ) {
+		return null;
+	}
+
+	const hideWidget = !! meta?.[ META_KEY ];
+
+	return (
+		<PluginDocumentSettingPanel
+			name="republication-tracker-tool-hide-widget"
+			title={ __(
+				'Hide Republication Widget',
+				'republication-tracker-tool'
+			) }
+		>
+			<ToggleControl
+				label={ __(
+					'Hide the Republication sharing widget on this post?',
+					'republication-tracker-tool'
+				) }
+				checked={ filterHides ? true : hideWidget }
+				disabled={ filterHides }
+				onChange={ ( value ) =>
+					setMeta( { ...meta, [ META_KEY ]: value } )
+				}
+				help={
+					filterHides
+						? createInterpolateElement(
+								__(
+									'The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',
+									'republication-tracker-tool'
+								),
+								{
+									code: <code />,
+									a: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href="https://github.com/Automattic/republication-tracker-tool/blob/trunk/docs/removing-republish-button-from-categories.md"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								}
+						  )
+						: undefined
+				}
+			/>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'republication-tracker-tool', {
+	render: RepublicationTrackerPanel,
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -16,31 +16,37 @@ const RepublicationTrackerPanel = () => {
 
 	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
 
-	const filterHides = useSelect(
-		( select ) =>
-			select( 'core/editor' ).getEditedPostAttribute(
+	const { filterHides, shareData } = useSelect( ( select ) => {
+		const editor = select( 'core/editor' );
+		return {
+			filterHides: editor.getEditedPostAttribute(
 				'republication_tracker_tool_filter_hides'
 			),
-		[]
-	);
+			shareData: editor.getEditedPostAttribute(
+				'republication_tracker_tool_share_data'
+			),
+		};
+	}, [] );
 
 	if ( 'post' !== postType ) {
 		return null;
 	}
 
 	const hideWidget = !! meta?.[ META_KEY ];
+	const total = shareData?.total ?? 0;
+	const entries = shareData?.entries ?? [];
 
 	return (
 		<PluginDocumentSettingPanel
-			name="republication-tracker-tool-hide-widget"
+			name="republication-tracker-tool"
 			title={ __(
-				'Hide Republication Widget',
+				'Republication Widget Settings',
 				'republication-tracker-tool'
 			) }
 		>
 			<ToggleControl
 				label={ __(
-					'Hide the Republication sharing widget on this post?',
+					'Hide Republication widget',
 					'republication-tracker-tool'
 				) }
 				checked={ filterHides ? true : hideWidget }
@@ -70,6 +76,50 @@ const RepublicationTrackerPanel = () => {
 						: undefined
 				}
 			/>
+			<p style={ { marginTop: '16px' } }>
+				{ __( 'Total number of views:', 'republication-tracker-tool' ) }{ ' ' }
+				{ total }
+			</p>
+			{ entries.length > 0 ? (
+				<table className="widefat striped">
+					<thead>
+						<tr>
+							<th>
+								{ __(
+									'Republished URL',
+									'republication-tracker-tool'
+								) }
+							</th>
+							<th>
+								{ __( 'Views', 'republication-tracker-tool' ) }
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ entries.map( ( entry ) => (
+							<tr key={ entry.url }>
+								<td>
+									<a
+										href={ entry.url }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ entry.url }
+									</a>
+								</td>
+								<td>{ entry.count }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			) : (
+				<p>
+					{ __(
+						'There are no shares to display.',
+						'republication-tracker-tool'
+					) }
+				</p>
+			) }
 		</PluginDocumentSettingPanel>
 	);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/editor'
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -57,8 +57,8 @@ const RepublicationTrackerPanel = () => {
 				}
 				help={
 					filterHides
-						// translators: <a> and </a> tags represent a link to the Republication Tracker README file on GitHub.
 						? createInterpolateElement(
+								// translators: <a> and </a> tags represent a link to the Republication Tracker README file on GitHub.
 								__(
 									'The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',
 									'republication-tracker-tool'

--- a/src/index.js
+++ b/src/index.js
@@ -1,32 +1,31 @@
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { ToggleControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
 const META_KEY = 'republication-tracker-tool-hide-widget';
 
 const RepublicationTrackerPanel = () => {
-	const postType = useSelect(
-		( select ) => select( 'core/editor' ).getCurrentPostType(),
+	const { postType, meta, filterHides, shareData } = useSelect(
+		( select ) => {
+			const editor = select( 'core/editor' );
+			return {
+				postType: editor.getCurrentPostType(),
+				meta: editor.getEditedPostAttribute( 'meta' ),
+				filterHides: editor.getEditedPostAttribute(
+					'republication_tracker_tool_filter_hides'
+				),
+				shareData: editor.getEditedPostAttribute(
+					'republication_tracker_tool_share_data'
+				),
+			};
+		},
 		[]
 	);
 
-	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
-
-	const { filterHides, shareData } = useSelect( ( select ) => {
-		const editor = select( 'core/editor' );
-		return {
-			filterHides: editor.getEditedPostAttribute(
-				'republication_tracker_tool_filter_hides'
-			),
-			shareData: editor.getEditedPostAttribute(
-				'republication_tracker_tool_share_data'
-			),
-		};
-	}, [] );
+	const { editPost } = useDispatch( 'core/editor' );
 
 	if ( 'post' !== postType ) {
 		return null;
@@ -52,7 +51,9 @@ const RepublicationTrackerPanel = () => {
 				checked={ filterHides ? true : hideWidget }
 				disabled={ filterHides }
 				onChange={ ( value ) =>
-					setMeta( { ...meta, [ META_KEY ]: value } )
+					editPost( {
+						meta: { ...( meta ?? {} ), [ META_KEY ]: value },
+					} )
 				}
 				help={
 					filterHides

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel } from '@wordpress/editor'
 import { ToggleControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -57,6 +57,7 @@ const RepublicationTrackerPanel = () => {
 				}
 				help={
 					filterHides
+						// translators: <a> and </a> tags represent a link to the Republication Tracker README file on GitHub.
 						? createInterpolateElement(
 								__(
 									'The Republication sharing widget on this post is programmatically disabled through the <code>hide_republication_widget</code> filter. <a>Read more about this filter</a>.',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,8 @@
+const path = require( 'path' );
+const getBaseWebpackConfig = require( 'newspack-scripts/config/getWebpackConfig' );
+
+const entry = {
+	index: path.join( __dirname, 'src', 'index.js' ),
+};
+
+module.exports = getBaseWebpackConfig( { entry } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Cherry-picked the changes from https://github.com/Automattic/republication-tracker-tool/pull/331 over to a new PR because it no longer needs to be a hotfix. This isn't a pressing change, but a nice modernization to the plugin that will likely be needed for WP 7.1 (when real-time collaboration gets reintroduced, and post meta boxes need to be phased out). 

Copied from the original PR:
This PR updates the Republication Tracker Tool's two post meta boxes to be compatible with WordPress 7.0's real-time collaboration. In general it's also just a nice modernization of the feature.

This PR also removes some dead code (the toggle to hide the widget originally appeared on pages, but they don't show the toggle anyway so this was unnecessary).

Closes NEWS-2174

### How to test the changes in this Pull Request:

1. Before applying the PR, edit at least one post and toggle off the Republication Tracker widget in the post's settings.
2. Add a republication tracker widget to one of the widget areas.
3. Apply the PR; run `npm ci && npm run build`. 
4. Edit the post and confirm the Hide Republication Tracker option now appears in the sidebar, and has a toggle to hide the widget on the current post, and the share count:

<img width="295" height="189" alt="CleanShot 2026-05-07 at 14 10 02" src="https://github.com/user-attachments/assets/cf2f658d-eb43-4fed-8428-a9a3b879ee79" />

5. Edit the post where you already toggled it on and confirm it's still on.
6. Edit a new post and try toggling the 'hide' option to on, and publish. 
7. Refresh the editor and confirm the setting 'stuck'. 
8. Confirm the widget is hidden on the front-end. 
9. Add the filter, `add_filter( 'hide_republication_widget', '__return_true' );` to the theme's function.php, or a mini-plugin (this was an existing filter in the plugin that let you hide the widget based on category, or entirely. When used, a message would display with the original checkbox).
10. Refresh the post editor, and confirm you now have a help text message pointing to the GitHub repo:

<img width="283" height="277" alt="CleanShot 2026-05-07 at 14 11 55" src="https://github.com/user-attachments/assets/e4c458f9-26bd-4a6f-a15a-fe09c666d6a6" />

### How to test with the Classic editor (bonus)

1. Install the Classic Editor plugin.
2. Edit a post and confirm you still have an option to toggle off the Republication Widget on a per post basis (likely in the sidebar), and that there's still a share count (likely at the bottom):

<img width="288" height="135" alt="CleanShot 2026-05-07 at 14 15 35" src="https://github.com/user-attachments/assets/0103a89f-2f04-4906-8d71-cf89f2462b30" />

<img width="1263" height="122" alt="CleanShot 2026-05-07 at 14 16 24" src="https://github.com/user-attachments/assets/b122cf36-7154-4023-9978-da69fae8f9eb" />

3. Confirm toggling on/off the hide option still works.